### PR TITLE
fix: dont encode with uri twice

### DIFF
--- a/src/editors/data/api.js
+++ b/src/editors/data/api.js
@@ -36,7 +36,7 @@ export async function fetchUnitById(updateContext, blockId, studioEndpointUrl) {
 
 export async function saveBlock(blockId, blockType, courseId, studioEndpointUrl, content, updateContext) {
   const normalizedContent = normalizeContent(blockType, content, blockId, courseId);
-  const url = `${studioEndpointUrl}/xblock/${encodeURI(blockId)}`;
+  const url = `${studioEndpointUrl}/xblock/${blockId}`;
   const params = [url, normalizedContent];
   saveAsync(updateContext, params);
 }


### PR DESCRIPTION
Just as the title says-- block key comes in encoded, don't encode it again. Will require a version bump in course authoring upon merge/release