### PR TITLE
Feat: empty gallery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,6 +1482,62 @@
         "pubsub-js": "1.9.4",
         "react-intl": "2.9.0",
         "universal-cookie": "4.0.4"
+<<<<<<< HEAD
+=======
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+          "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "intl-messageformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+          "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+          "dev": true,
+          "requires": {
+            "intl-messageformat-parser": "1.4.0"
+          }
+        },
+        "intl-messageformat-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+          "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=",
+          "dev": true
+        },
+        "react-intl": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
+          "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
+          "dev": true,
+          "requires": {
+            "hoist-non-react-statics": "^3.3.0",
+            "intl-format-cache": "^2.0.5",
+            "intl-messageformat": "^2.1.0",
+            "intl-relativeformat": "^2.1.0",
+            "invariant": "^2.1.1"
+          }
+        }
+>>>>>>> 8879e59 (fix: ran npm install for lodash-es)
       }
     },
     "@edx/new-relic-source-map-webpack-plugin": {
@@ -9059,23 +9115,6 @@
       "integrity": "sha512-Zv/u8wRpekckv0cLkwpVdABYST4hZNTDaX7reFetrYTJwxExR2VyTqQm+l0WmL0Qo8Mjb9Tf33qnfj0T7pjxdQ==",
       "dev": true
     },
-    "intl-messageformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
-      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
-      "dev": true,
-      "requires": {
-        "intl-messageformat-parser": "1.4.0"
-      },
-      "dependencies": {
-        "intl-messageformat-parser": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-          "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=",
-          "dev": true
-        }
-      }
-    },
     "intl-messageformat-parser": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.5.1.tgz",
@@ -13990,19 +14029,6 @@
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.2.5",
         "use-sidecar": "^1.0.5"
-      }
-    },
-    "react-intl": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
-      "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "^3.3.0",
-        "intl-format-cache": "^2.0.5",
-        "intl-messageformat": "^2.1.0",
-        "intl-relativeformat": "^2.1.0",
-        "invariant": "^2.1.1"
       }
     },
     "react-is": {

--- a/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
@@ -15,7 +15,8 @@ import messages from './messages';
 import GalleryCard from './GalleryCard';
 
 export const Gallery = ({
-  isEmpty,
+  galleryIsEmpty,
+  searchIsEmpty,
   displayList,
   highlighted,
   onHighlightChange,
@@ -33,10 +34,17 @@ export const Gallery = ({
       />
     );
   }
-  if (isEmpty) {
+  if (galleryIsEmpty) {
     return (
       <div className="gallery p-4 bg-gray-100" style={{ height: '375px' }}>
         <FormattedMessage {...messages.emptyGalleryLabel} />
+      </div>
+    );
+  }
+  if (searchIsEmpty) {
+    return (
+      <div className="gallery p-4 bg-gray-100" style={{ height: '375px' }}>
+        <FormattedMessage {...messages.emptySearchLabel} />
       </div>
     );
   }
@@ -61,7 +69,8 @@ Gallery.defaultProps = {
   highlighted: '',
 };
 Gallery.propTypes = {
-  isEmpty: PropTypes.bool.isRequired,
+  galleryIsEmpty: PropTypes.bool.isRequired,
+  searchIsEmpty: PropTypes.bool.isRequired,
   displayList: PropTypes.arrayOf(PropTypes.object).isRequired,
   highlighted: PropTypes.string,
   onHighlightChange: PropTypes.func.isRequired,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
@@ -6,7 +6,7 @@ import {
   Scrollable, SelectableBox, Spinner,
 } from '@edx/paragon';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import { selectors } from '../../../../data/redux';
 import { RequestKeys } from '../../../../data/constants/requests';
@@ -35,8 +35,8 @@ export const Gallery = ({
   }
   if (isEmpty) {
     return (
-      <div style={{ height: '375px' }}>
-        No images found. Please upload an image using the button below.
+      <div className="gallery p-4 bg-gray-100" style={{ height: '375px' }}>
+        <FormattedMessage {...messages.emptyGalleryLabel} />
       </div>
     );
   }

--- a/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.jsx
@@ -15,6 +15,7 @@ import messages from './messages';
 import GalleryCard from './GalleryCard';
 
 export const Gallery = ({
+  isEmpty,
   displayList,
   highlighted,
   onHighlightChange,
@@ -30,6 +31,13 @@ export const Gallery = ({
         className="mie-3"
         screenReaderText={intl.formatMessage(messages.loading)}
       />
+    );
+  }
+  if (isEmpty) {
+    return (
+      <div style={{ height: '375px' }}>
+        No images found. Please upload an image using the button below.
+      </div>
     );
   }
   return (
@@ -53,6 +61,7 @@ Gallery.defaultProps = {
   highlighted: '',
 };
 Gallery.propTypes = {
+  isEmpty: PropTypes.bool.isRequired,
   displayList: PropTypes.arrayOf(PropTypes.object).isRequired,
   highlighted: PropTypes.string,
   onHighlightChange: PropTypes.func.isRequired,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.test.jsx
@@ -19,7 +19,8 @@ jest.mock('./GalleryCard', () => 'GalleryCard');
 describe('TextEditor Image Gallery component', () => {
   describe('component', () => {
     const props = {
-      isEmpty: false,
+      galleryIsEmpty: false,
+      searchIsEmpty: false,
       displayList: [{ id: 1 }, { id: 2 }, { id: 3 }],
       highlighted: 'props.highlighted',
       onHighlightChange: jest.fn().mockName('props.onHighlightChange'),
@@ -30,7 +31,10 @@ describe('TextEditor Image Gallery component', () => {
       expect(shallow(<Gallery {...props} isLoaded={false} />)).toMatchSnapshot();
     });
     test('snapshot: loaded but no images, show empty gallery', () => {
-      expect(shallow(<Gallery {...props} isEmpty={true} />)).toMatchSnapshot();
+      expect(shallow(<Gallery {...props} galleryIsEmpty />)).toMatchSnapshot();
+    });
+    test('snapshot: loaded but search returns no images, show 0 search result gallery', () => {
+      expect(shallow(<Gallery {...props} searchIsEmpty />)).toMatchSnapshot();
     });
     test('snapshot: loaded, show gallery', () => {
       expect(shallow(<Gallery {...props} />)).toMatchSnapshot();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/Gallery.test.jsx
@@ -19,6 +19,7 @@ jest.mock('./GalleryCard', () => 'GalleryCard');
 describe('TextEditor Image Gallery component', () => {
   describe('component', () => {
     const props = {
+      isEmpty: false,
       displayList: [{ id: 1 }, { id: 2 }, { id: 3 }],
       highlighted: 'props.highlighted',
       onHighlightChange: jest.fn().mockName('props.onHighlightChange'),
@@ -27,6 +28,9 @@ describe('TextEditor Image Gallery component', () => {
     };
     test('snapshot: not loaded, show spinner', () => {
       expect(shallow(<Gallery {...props} isLoaded={false} />)).toMatchSnapshot();
+    });
+    test('snapshot: loaded but no images, show empty gallery', () => {
+      expect(shallow(<Gallery {...props} isEmpty={true} />)).toMatchSnapshot();
     });
     test('snapshot: loaded, show gallery', () => {
       expect(shallow(<Gallery {...props} />)).toMatchSnapshot();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextEditor Image Gallery component component snapshot: loaded but no images, show empty gallery 1`] = `
+<div
+  className="gallery p-4 bg-gray-100"
+  style={
+    Object {
+      "height": "375px",
+    }
+  }
+>
+  <FormattedMessage
+    defaultMessage="No images found. Please upload an image using the button below."
+    description="Label for when image gallery is empty."
+    id="authoring.texteditor.selectimagemodal.emptyGalleryLabel"
+  />
+</div>
+`;
+
 exports[`TextEditor Image Gallery component component snapshot: loaded, show gallery 1`] = `
 <Scrollable
   className="gallery bg-gray-100"

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
@@ -27,7 +27,7 @@ exports[`TextEditor Image Gallery component component snapshot: loaded but searc
   }
 >
   <FormattedMessage
-    defaultMessage="0 search results."
+    defaultMessage="No search results."
     description="Label for when search returns nothing."
     id="authoring.texteditor.selectimagemodal.emptySearchLabel"
   />

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/Gallery.test.jsx.snap
@@ -10,9 +10,26 @@ exports[`TextEditor Image Gallery component component snapshot: loaded but no im
   }
 >
   <FormattedMessage
-    defaultMessage="No images found. Please upload an image using the button below."
+    defaultMessage="No images found in your gallery. Please upload an image using the button below."
     description="Label for when image gallery is empty."
     id="authoring.texteditor.selectimagemodal.emptyGalleryLabel"
+  />
+</div>
+`;
+
+exports[`TextEditor Image Gallery component component snapshot: loaded but search returns no images, show 0 search result gallery 1`] = `
+<div
+  className="gallery p-4 bg-gray-100"
+  style={
+    Object {
+      "height": "375px",
+    }
+  }
+>
+  <FormattedMessage
+    defaultMessage="0 search results."
+    description="Label for when search returns nothing."
+    id="authoring.texteditor.selectimagemodal.emptySearchLabel"
   />
 </div>
 `;

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -40,6 +40,7 @@ export const imgListHooks = ({
   const dispatch = useDispatch();
   const [images, setImages] = module.state.images({});
   const [highlighted, setHighlighted] = module.state.highlighted(null);
+  const list = module.displayList({ ...searchSortProps, images });
 
   React.useEffect(() => {
     dispatch(thunkActions.app.fetchImages({ setImages }));
@@ -53,10 +54,11 @@ export const imgListHooks = ({
       onClick: () => setSelection(images[highlighted]),
     },
     galleryProps: {
-      isEmpty: Object.keys(images).length === 4,
+      galleryIsEmpty: Object.keys(images).length === 0,
+      searchIsEmpty: list.length === 0,
+      displayList: list,
       highlighted,
       onHighlightChange: e => setHighlighted(e.target.value),
-      displayList: module.displayList({ ...searchSortProps, images }),
     },
   };
 };

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -53,6 +53,7 @@ export const imgListHooks = ({
       onClick: () => setSelection(images[highlighted]),
     },
     galleryProps: {
+      isEmpty: Object.keys(images).length === 4,
       highlighted,
       onHighlightChange: e => setHighlighted(e.target.value),
       displayList: module.displayList({ ...searchSortProps, images }),

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -66,8 +66,13 @@ export const messages = {
   },
   emptyGalleryLabel: {
     id: 'authoring.texteditor.selectimagemodal.emptyGalleryLabel',
-    defaultMessage: 'No images found. Please upload an image using the button below.',
+    defaultMessage: 'No images found in your gallery. Please upload an image using the button below.',
     description: 'Label for when image gallery is empty.',
+  },
+  emptySearchLabel: {
+    id: 'authoring.texteditor.selectimagemodal.emptySearchLabel',
+    defaultMessage: '0 search results.',
+    description: 'Label for when search returns nothing.',
   },
 };
 

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -71,7 +71,7 @@ export const messages = {
   },
   emptySearchLabel: {
     id: 'authoring.texteditor.selectimagemodal.emptySearchLabel',
-    defaultMessage: '0 search results.',
+    defaultMessage: 'No search results.',
     description: 'Label for when search returns nothing.',
   },
 };

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -64,6 +64,11 @@ export const messages = {
     defaultMessage: 'Error',
     description: 'Title of message presented to user when something goes wrong',
   },
+  emptyGalleryLabel: {
+    id: 'authoring.texteditor.selectimagemodal.emptyGalleryLabel',
+    defaultMessage: 'No images found. Please upload an image using the button below.',
+    description: 'Label for when image gallery is empty.',
+  },
 };
 
 export default messages;


### PR DESCRIPTION
Added 2 labels for when gallery is empty:

1. When no images are returned from backend.
2. When search returns 0 results.

This does not match the mockups in figma and is more of a quick temporary solution. 