### PR TITLE
fix: update texteditor spacing

### DIFF
--- a/src/editors/components/EditorFooter/__snapshots__/index.test.jsx.snap
+++ b/src/editors/components/EditorFooter/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EditorFooter snapshots Save Failed, error message raised 1`] = `
 <div
-  className="editor-footer mt-auto"
+  className="editor-footer fixed-bottom"
 >
   <Toast
     onClose={[MockFunction nullMethod]}
@@ -60,7 +60,7 @@ exports[`EditorFooter snapshots Save Failed, error message raised 1`] = `
 
 exports[`EditorFooter snapshots not intialized, Spinner appears and button is disabled 1`] = `
 <div
-  className="editor-footer mt-auto"
+  className="editor-footer fixed-bottom"
 >
   <ModalDialog.Footer>
     <ActionRow>
@@ -107,7 +107,7 @@ exports[`EditorFooter snapshots not intialized, Spinner appears and button is di
 
 exports[`EditorFooter snapshots renders as expected with default behavior 1`] = `
 <div
-  className="editor-footer mt-auto"
+  className="editor-footer fixed-bottom"
 >
   <ModalDialog.Footer>
     <ActionRow>

--- a/src/editors/components/EditorFooter/index.jsx
+++ b/src/editors/components/EditorFooter/index.jsx
@@ -31,7 +31,7 @@ export const EditorFooter = ({
   saveFailed,
   saveBlockContent,
 }) => (
-  <div className="editor-footer mt-auto">
+  <div className="editor-footer fixed-bottom">
     {saveFailed && (
       <Toast show onClose={nullMethod}><FormattedMessage {...messages.contentSaveFailed} /></Toast>
     )}

--- a/src/editors/containers/TextEditor/TextEditor.jsx
+++ b/src/editors/containers/TextEditor/TextEditor.jsx
@@ -53,7 +53,7 @@ export const TextEditor = ({
   const imageSelection = selectedImage(null);
 
   return (
-    <div className="editor-body h-75">
+    <div className="editor-body h-75 overflow-auto">
       <ImageUploadModal
         isOpen={isOpen}
         close={closeModal}

--- a/src/editors/containers/TextEditor/__snapshots__/TextEditor.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/TextEditor.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
 <div
-  className="editor-body h-75"
+  className="editor-body h-75 overflow-auto"
 >
   <ImageUploadModal
     clearSelection={[MockFunction hooks.selectedImage.clearSelection]}
@@ -49,7 +49,7 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
 
 exports[`TextEditor snapshots not yet loaded, Spinner appears 1`] = `
 <div
-  className="editor-body h-75"
+  className="editor-body h-75 overflow-auto"
 >
   <ImageUploadModal
     clearSelection={[MockFunction hooks.selectedImage.clearSelection]}
@@ -89,7 +89,7 @@ exports[`TextEditor snapshots not yet loaded, Spinner appears 1`] = `
 
 exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
 <div
-  className="editor-body h-75"
+  className="editor-body h-75 overflow-auto"
 >
   <ImageUploadModal
     clearSelection={[MockFunction hooks.selectedImage.clearSelection]}

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -97,7 +97,7 @@ export const editorConfig = ({
     imagetools_toolbar: module.getConfig('imageToolbar'),
     imagetools_cors_hosts: ['courses.edx.org'],
     height: '100%',
-    min_height: 1000,
+    min_height: 500,
     branding: false,
   },
 });

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -134,7 +134,7 @@ describe('TextEditor hooks', () => {
         expect(output.init.menubar).toBe(false);
         expect(output.init.imagetools_cors_hosts).toMatchObject(['courses.edx.org']);
         expect(output.init.height).toBe('100%');
-        expect(output.init.min_height).toBe(1000);
+        expect(output.init.min_height).toBe(500);
         expect(output.init.branding).toBe(false);
       });
     });


### PR DESCRIPTION
Screenshots show how footer is now locked to bottom of page, and that text editor content scrolls, and that this works on resize of page.

<img width="665" alt="Screen Shot 2022-04-07 at 9 34 00 AM" src="https://user-images.githubusercontent.com/49422820/162211227-38661b90-8662-4e47-840a-f58c4859a870.png">
<img width="1415" alt="Screen Shot 2022-04-07 at 9 33 54 AM" src="https://user-images.githubusercontent.com/49422820/162211231-4805392e-25c5-4171-83b0-cf24e9ac69e8.png">
<img width="1410" alt="Screen Shot 2022-04-07 at 9 33 36 AM" src="https://user-images.githubusercontent.com/49422820/162211234-69b8d54a-8b81-4fe9-b1d9-68298702d2dc.png">

