### PR TITLE
Tnl 9804 make small code stewardship changes to frontend lib content components

### DIFF
--- a/src/editors/components/EditorFooter/__snapshots__/index.test.jsx.snap
+++ b/src/editors/components/EditorFooter/__snapshots__/index.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`EditorFooter snapshots Save Failed, error message raised 1`] = `
         }
       >
         <FormattedMessage
-          defaultMessage="Save"
+          defaultMessage="Save Changes and Return to Learning Context"
           description="Label for Save button"
           id="authoring.editorfooter.savebutton.label"
         />
@@ -143,7 +143,7 @@ exports[`EditorFooter snapshots renders as expected with default behavior 1`] = 
         }
       >
         <FormattedMessage
-          defaultMessage="Save"
+          defaultMessage="Save Changes and Return to Learning Context"
           description="Label for Save button"
           id="authoring.editorfooter.savebutton.label"
         />

--- a/src/editors/components/EditorFooter/index.jsx
+++ b/src/editors/components/EditorFooter/index.jsx
@@ -56,7 +56,7 @@ export const EditorFooter = ({
           disabled={!isInitialized}
         >
           {isInitialized
-            ? <FormattedMessage {...messages.addToCourse} />
+            ? <FormattedMessage {...messages.saveButtonLabel} />
             : <Spinner animation="border" className="mr-3" />}
         </Button>
       </ActionRow>

--- a/src/editors/components/EditorFooter/messages.js
+++ b/src/editors/components/EditorFooter/messages.js
@@ -19,9 +19,9 @@ export const messages = {
     defaultMessage: 'Save Changes and Return to Learning Context',
     description: 'Aria label for save button',
   },
-  addToCourse: {
+  saveButtonLabel: {
     id: 'authoring.editorfooter.savebutton.label',
-    defaultMessage: 'Save',
+    defaultMessage: 'Save Changes and Return to Learning Context',
     description: 'Label for Save button',
   },
 };

--- a/src/editors/components/EditorHeader/messages.js
+++ b/src/editors/components/EditorHeader/messages.js
@@ -1,8 +1,8 @@
 export const messages = {
   loading: {
     id: 'authoring.texteditor.title.loading',
-    description: 'Message displayed while loading content',
     defaultMessage: 'Loading...',
+    description: 'Message displayed while loading content',
   },
   cancelChangesLabel: {
     id: 'authoring.texteditor.header.cancelChangesLabel',


### PR DESCRIPTION
Miniature code stewardship changes to editor.
- Consistent ordering of attribute types describing header and footer
- Consistent button description for Save button