### PR TITLE
fix: Fix pull_translations by using correct CLI flag for languages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --language=$(transifex_langs)
+	tx pull -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
Docs: https://developers.transifex.com/docs/using-the-client

Apparently this CLI option changed from singular to plural at some point.