### PR TITLE
fix: added underline option to toolbar. TNL-10003

### DIFF
--- a/src/editors/containers/TextEditor/pluginConfig.js
+++ b/src/editors/containers/TextEditor/pluginConfig.js
@@ -21,7 +21,7 @@ export default StrictDict({
   toolbar: mapToolbars([
     [buttons.undo, buttons.redo],
     [buttons.formatSelect],
-    [buttons.bold, buttons.italic, buttons.foreColor, buttons.backColor],
+    [buttons.bold, buttons.italic, buttons.underline, buttons.foreColor, buttons.backColor],
     [
       buttons.align.left,
       buttons.align.center,

--- a/src/editors/data/constants/tinyMCE.js
+++ b/src/editors/data/constants/tinyMCE.js
@@ -48,6 +48,7 @@ export const buttons = StrictDict({
   }),
   table: 'table',
   undo: 'undo',
+  underline: 'underline',
 });
 
 export const plugins = listKeyStore([


### PR DESCRIPTION
## Description
This PR adds the missing text underline button and functionality to the Text Editor toolbar. To add the functionality, a new parameter was added to the tinyMCE configuration. No new tests required since toolbar tests are already present and cover the new button.
Jira Ticket: [TNL-10003](https://2u-internal.atlassian.net/browse/TNL-10003?atlOrigin=eyJpIjoiZGU2MTNmZDNhNzdkNDZlOWJjZDAzMGU3MWZmYzY1ZjQiLCJwIjoiaiJ9)