### PR TITLE
feat: Prevent image uploads larger than 10 MB and add spinner

### DIFF
--- a/src/editors/containers/TextEditor/components/ErrorAlerts/__snapshots__/FetchErrorAlert.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/ErrorAlerts/__snapshots__/FetchErrorAlert.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`FetchErrorAlert Snapshots snapshot:  is ErrorAlert with Message error (
   isError={true}
 >
   <FormattedMessage
-    defaultMessage="Failed to obtain course Images. Please Try again."
+    defaultMessage="Failed to obtain course images. Please try again."
     description="Message presented to user when images are not found"
     id="authoring.texteditor.selectimagemodal.error.fetchImagesError"
   />

--- a/src/editors/containers/TextEditor/components/ErrorAlerts/__snapshots__/UploadErrorAlert.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/ErrorAlerts/__snapshots__/UploadErrorAlert.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`UploadErrorAlert Snapshots snapshot:  is ErrorAlert with Message error 
   isError={true}
 >
   <FormattedMessage
-    defaultMessage="Failed to Upload Image. Please Try again."
+    defaultMessage="Failed to upload image. Please try again."
     description="Message presented to user when image fails to upload"
     id="authoring.texteditor.selectimagemodal.error.uploadImageError"
   />

--- a/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
+++ b/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
@@ -1,30 +1,31 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-import tinyMCEKeys from '../../../data/constants/tinyMCE';
-import ImageSettingsModal from './ImageSettingsModal';
-import SelectImageModal from './SelectImageModal';
-import * as module from './ImageUploadModal';
+import tinyMCEKeys from "../../../data/constants/tinyMCE";
+import ImageSettingsModal from "./ImageSettingsModal";
+import SelectImageModal from "./SelectImageModal";
+import * as module from "./ImageUploadModal";
 
-export const propsString = (props) => Object.keys(props)
-  .map(key => `${key}="${props[key]}"`)
-  .join(' ');
+export const propsString = (props) =>
+  Object.keys(props)
+    .map((key) => `${key}="${props[key]}"`)
+    .join(" ");
 
 export const imgProps = ({ settings, selection }) => ({
   src: selection.externalUrl,
-  alt: settings.isDecorative ? '' : settings.altText,
+  alt: settings.isDecorative ? "" : settings.altText,
   width: settings.dimensions.width,
   height: settings.dimensions.height,
 });
 
 export const hooks = {
-  createSaveCallback: ({
-    close, editorRef, setSelection, selection,
-  }) => (settings) => {
+  createSaveCallback: ({ close, editorRef, setSelection, selection }) => (
+    settings
+  ) => {
     editorRef.current.execCommand(
       tinyMCEKeys.commands.insertContent,
       false,
-      module.hooks.imgTag({ settings, selection }),
+      module.hooks.imgTag({ settings, selection })
     );
     setSelection(null);
     close();
@@ -67,7 +68,7 @@ export const ImageUploadModal = ({
     );
   }
   return (
-    <SelectImageModal {...{ isOpen, close, setSelection }} />
+    <SelectImageModal {...{ isOpen, close, setSelection, clearSelection }} />
   );
 };
 

--- a/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
+++ b/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
@@ -1,31 +1,35 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import tinyMCEKeys from "../../../data/constants/tinyMCE";
-import ImageSettingsModal from "./ImageSettingsModal";
-import SelectImageModal from "./SelectImageModal";
-import * as module from "./ImageUploadModal";
+import tinyMCEKeys from '../../../data/constants/tinyMCE';
+import ImageSettingsModal from './ImageSettingsModal';
+import SelectImageModal from './SelectImageModal';
+import * as module from './ImageUploadModal';
 
 export const propsString = (props) =>
-  Object.keys(props)
-    .map((key) => `${key}="${props[key]}"`)
-    .join(" ");
+  Object.keys(props).map((key) => `${key}="${props[key]}"`)
+    .join(' ');
 
 export const imgProps = ({ settings, selection }) => ({
   src: selection.externalUrl,
-  alt: settings.isDecorative ? "" : settings.altText,
+  alt: settings.isDecorative ? '' : settings.altText,
   width: settings.dimensions.width,
   height: settings.dimensions.height,
 });
 
 export const hooks = {
-  createSaveCallback: ({ close, editorRef, setSelection, selection }) => (
-    settings
+  createSaveCallback: ({
+    close,
+    editorRef,
+    setSelection,
+    selection,
+  }) => (
+    settings,
   ) => {
     editorRef.current.execCommand(
       tinyMCEKeys.commands.insertContent,
       false,
-      module.hooks.imgTag({ settings, selection })
+      module.hooks.imgTag({ settings, selection, })
     );
     setSelection(null);
     close();
@@ -68,7 +72,12 @@ export const ImageUploadModal = ({
     );
   }
   return (
-    <SelectImageModal {...{ isOpen, close, setSelection, clearSelection }} />
+    <SelectImageModal {...{
+      isOpen,
+      close,
+      setSelection,
+      clearSelection
+    }} />
   );
 };
 

--- a/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
+++ b/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
@@ -7,8 +7,7 @@ import SelectImageModal from './SelectImageModal';
 import * as module from './ImageUploadModal';
 
 export const propsString = (props) =>
-  Object.keys(props).map((key) => `${key}="${props[key]}"`)
-    .join(' ');
+  Object.keys(props).map((key) => `${key}="${props[key]}"`).join(' ');
 
 export const imgProps = ({ settings, selection }) => ({
   src: selection.externalUrl,
@@ -29,7 +28,7 @@ export const hooks = {
     editorRef.current.execCommand(
       tinyMCEKeys.commands.insertContent,
       false,
-      module.hooks.imgTag({ settings, selection, })
+      module.hooks.imgTag({ settings, selection }),
     );
     setSelection(null);
     close();
@@ -72,12 +71,14 @@ export const ImageUploadModal = ({
     );
   }
   return (
-    <SelectImageModal {...{
-      isOpen,
-      close,
-      setSelection,
-      clearSelection
-    }} />
+    <SelectImageModal
+      {...{
+        isOpen,
+        close,
+        setSelection,
+        clearSelection,
+      }}
+    />
   );
 };
 

--- a/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
+++ b/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
@@ -6,8 +6,9 @@ import ImageSettingsModal from './ImageSettingsModal';
 import SelectImageModal from './SelectImageModal';
 import * as module from './ImageUploadModal';
 
-export const propsString = (props) =>
-  Object.keys(props).map((key) => `${key}="${props[key]}"`).join(' ');
+export const propsString = (props) => (
+  Object.keys(props).map((key) => `${key}="${props[key]}"`).join(' ')
+);
 
 export const imgProps = ({ settings, selection }) => ({
   src: selection.externalUrl,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
@@ -136,8 +136,10 @@ exports[`SelectImageModal component snapshot: uploaded image not loaded, show sp
     <SearchSort
       search="sortProps"
     />
-    <Gallery
-      gallery="props"
+    <Spinner
+      animation="border"
+      className="mie-3"
+      screenReaderText="loading..."
     />
     <FileInput
       fileInput={

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`SelectImageModal component snapshot 1`] = `
       variant="link"
     >
       <FormattedMessage
-        defaultMessage="Upload a new image"
+        defaultMessage="Upload a new image (10 MB max)"
         description="Label for upload button"
         id="authoring.texteditor.selectimagemodal.upload.label"
       />
@@ -35,7 +35,18 @@ exports[`SelectImageModal component snapshot 1`] = `
   <ErrorAlert
     dismissError={[MockFunction]}
     hideHeading={true}
-    isError="ShoWERror"
+    isError="ShoWERror inPUT"
+  >
+    <FormattedMessage
+      defaultMessage="Images must be 10 MB or less. Please resize image and try again."
+      description=" Message presented to user when file size of image is larger than 10 MB"
+      id="authoring.texteditor.selectimagemodal.error.fileSizeError"
+    />
+  </ErrorAlert>
+  <ErrorAlert
+    dismissError={[MockFunction]}
+    hideHeading={true}
+    isError="ShoWERror gAlLery"
   >
     <FormattedMessage
       defaultMessage="Select an image to continue."

--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/index.test.jsx.snap
@@ -75,3 +75,79 @@ exports[`SelectImageModal component snapshot 1`] = `
   </Stack>
 </BaseModal>
 `;
+
+exports[`SelectImageModal component snapshot: uploaded image not loaded, show spinner 1`] = `
+<BaseModal
+  close={[MockFunction props.close]}
+  confirmAction={
+    <Button
+      select="btnProps"
+      variant="primary"
+    >
+      <FormattedMessage
+        defaultMessage="Next"
+        description="Label for Next button"
+        id="authoring.texteditor.selectimagemodal.next.label"
+      />
+    </Button>
+  }
+  footerAction={
+    <Button
+      onClick="imgHooks.fileInput.click"
+      variant="link"
+    >
+      <FormattedMessage
+        defaultMessage="Upload a new image (10 MB max)"
+        description="Label for upload button"
+        id="authoring.texteditor.selectimagemodal.upload.label"
+      />
+    </Button>
+  }
+  isOpen={true}
+  title="Add an image"
+>
+  <FetchErrorAlert />
+  <UploadErrorAlert />
+  <ErrorAlert
+    dismissError={[MockFunction]}
+    hideHeading={true}
+    isError="ShoWERror inPUT"
+  >
+    <FormattedMessage
+      defaultMessage="Images must be 10 MB or less. Please resize image and try again."
+      description=" Message presented to user when file size of image is larger than 10 MB"
+      id="authoring.texteditor.selectimagemodal.error.fileSizeError"
+    />
+  </ErrorAlert>
+  <ErrorAlert
+    dismissError={[MockFunction]}
+    hideHeading={true}
+    isError="ShoWERror gAlLery"
+  >
+    <FormattedMessage
+      defaultMessage="Select an image to continue."
+      description="Message presented to user when clicking Next without selecting an image"
+      id="authoring.texteditor.selectimagemodal.error.selectImageError"
+    />
+  </ErrorAlert>
+  <Stack
+    gap={3}
+  >
+    <SearchSort
+      search="sortProps"
+    />
+    <Gallery
+      gallery="props"
+    />
+    <FileInput
+      fileInput={
+        Object {
+          "addFile": "imgHooks.fileInput.addFile",
+          "click": "imgHooks.fileInput.click",
+          "ref": "imgHooks.fileInput.ref",
+        }
+      }
+    />
+  </Stack>
+</BaseModal>
+`;

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -30,11 +30,11 @@ export const filteredList = ({ searchString, imageList }) => (
   imageList.filter(({ displayName }) => displayName.toLowerCase().includes(searchString.toLowerCase()))
 );
 
-export const displayList = ({ sortBy, searchString, images }) =>
+export const displayList = ({ sortBy, searchString, images }) => (
   module.filteredList({
     searchString,
     imageList: Object.values(images),
-  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]);
+  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]));
 
 export const imgListHooks = ({ searchSortProps, setSelection }) => {
   const dispatch = useDispatch();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -88,8 +88,8 @@ export const checkValidFileSize = ({
   clearSelection,
   onSizeFail,
 }) => {
-  const fileSize = (selectedFile.size / 1000000).toFixed(4);
-  if (fileSize > 10) {
+  // Check if the file size is greater than 10 MB, upload size limit
+  if (selectedFile.size > 1000000) {
     clearSelection();
     onSizeFail();
     return false;

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -110,12 +110,11 @@ export const fileInputHooks = ({ setSelection, clearSelection, imgList }) => {
   const click = () => ref.current.click();
   const addFile = (e) => {
     const selectedFile = e.target.files[0];
-    if (
+    if (selectedFile &&
       module.checkValidFileSize({
         selectedFile,
         clearSelection,
         onSizeFail: () => {
-          console.log(imgList);
           imgList.inputError.set();
         },
       })

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -1,9 +1,9 @@
-import React from "react";
-import { useDispatch } from "react-redux";
+import React from 'react';
+import { useDispatch } from 'react-redux';
 
-import { thunkActions } from "../../../../data/redux";
-import * as module from "./hooks";
-import { sortFunctions, sortKeys } from "./utils";
+import { thunkActions } from '../../../../data/redux';
+import * as module from './hooks';
+import { sortFunctions, sortKeys } from './utils';
 
 export const state = {
   highlighted: (val) => React.useState(val),
@@ -15,31 +15,26 @@ export const state = {
 };
 
 export const searchAndSortHooks = () => {
-  const [searchString, setSearchString] = module.state.searchString("");
+  const [searchString, setSearchString] = module.state.searchString('');
   const [sortBy, setSortBy] = module.state.sortBy(sortKeys.dateNewest);
   return {
     searchString,
     onSearchChange: (e) => setSearchString(e.target.value),
-    clearSearchString: () => setSearchString(""),
+    clearSearchString: () => setSearchString(''),
     sortBy,
     onSortClick: (key) => () => setSortBy(key),
   };
 };
 
-export const filteredList = ({ searchString, imageList }) =>
-  imageList.filter(({ displayName }) =>
-    displayName.toLowerCase().includes(searchString.toLowerCase())
-  );
+export const filteredList = ({ searchString, imageList }) => (
+  imageList.filter(({ displayName }) =>displayName.toLowerCase().includes(searchString.toLowerCase()))
+);
 
 export const displayList = ({ sortBy, searchString, images }) =>
-  module
-    .filteredList({
+  module.filteredList({
       searchString,
       imageList: Object.values(images),
-    })
-    .sort(
-      sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]
-    );
+    }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]);
 
 export const imgListHooks = ({ searchSortProps, setSelection }) => {
   const dispatch = useDispatch();
@@ -49,9 +44,7 @@ export const imgListHooks = ({ searchSortProps, setSelection }) => {
     showSelectImageError,
     setShowSelectImageError,
   ] = module.state.showSelectImageError(false);
-  const [showSizeError, setShowSizeError] = module.state.showSelectImageError(
-    false
-  );
+  const [showSizeError, setShowSizeError] = module.state.showSelectImageError(false);
   const list = module.displayList({ ...searchSortProps, images });
 
   React.useEffect(() => {
@@ -97,7 +90,7 @@ export const checkValidFileSize = ({
 }) => {
   const fileSize = (selectedFile.size / 1000000).toFixed(4);
   if (fileSize > 10) {
-    clearSelection;
+    clearSelection();
     onSizeFail();
     return false;
   }
@@ -110,8 +103,7 @@ export const fileInputHooks = ({ setSelection, clearSelection, imgList }) => {
   const click = () => ref.current.click();
   const addFile = (e) => {
     const selectedFile = e.target.files[0];
-    if (selectedFile &&
-      module.checkValidFileSize({
+    if (selectedFile && module.checkValidFileSize({
         selectedFile,
         clearSelection,
         onSizeFail: () => {
@@ -123,7 +115,7 @@ export const fileInputHooks = ({ setSelection, clearSelection, imgList }) => {
         thunkActions.app.uploadImage({
           file: selectedFile,
           setSelection,
-        })
+        }),
       );
     }
   };
@@ -143,7 +135,12 @@ export const imgHooks = ({ setSelection, clearSelection }) => {
     clearSelection,
     imgList,
   });
-  const { galleryError, galleryProps, inputError, selectBtnProps } = imgList;
+  const {
+    galleryError,
+    galleryProps,
+    inputError,
+    selectBtnProps,
+  } = imgList;
 
   return {
     galleryError,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -27,14 +27,14 @@ export const searchAndSortHooks = () => {
 };
 
 export const filteredList = ({ searchString, imageList }) => (
-  imageList.filter(({ displayName }) =>displayName.toLowerCase().includes(searchString.toLowerCase()))
+  imageList.filter(({ displayName }) => displayName.toLowerCase().includes(searchString.toLowerCase()))
 );
 
 export const displayList = ({ sortBy, searchString, images }) =>
   module.filteredList({
-      searchString,
-      imageList: Object.values(images),
-    }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]);
+    searchString,
+    imageList: Object.values(images),
+  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]);
 
 export const imgListHooks = ({ searchSortProps, setSelection }) => {
   const dispatch = useDispatch();
@@ -104,13 +104,12 @@ export const fileInputHooks = ({ setSelection, clearSelection, imgList }) => {
   const addFile = (e) => {
     const selectedFile = e.target.files[0];
     if (selectedFile && module.checkValidFileSize({
-        selectedFile,
-        clearSelection,
-        onSizeFail: () => {
-          imgList.inputError.set();
-        },
-      })
-    ) {
+      selectedFile,
+      clearSelection,
+      onSizeFail: () => {
+        imgList.inputError.set();
+      },
+    })) {
       dispatch(
         thunkActions.app.uploadImage({
           file: selectedFile,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -55,7 +55,7 @@ const state = new MockUseState(hooks);
 const hookKeys = keyStore(hooks);
 let hook;
 const testValue = 'testVALUEVALIDIMAGE';
-const testValueInvalidImage = {;value:'testVALUEVALIDIMAGE', size: 90000000 };
+const testValueInvalidImage = { value:'testVALUEVALIDIMAGE', size: 90000000 };
 
 describe('SelectImageModal hooks', () => {
   beforeEach(() => {
@@ -243,6 +243,7 @@ describe('SelectImageModal hooks', () => {
     const setSelection = jest.fn();
     const clearSelection = jest.fn();
     const imgList = { inputError: { show: true, dismiss: jest.fn(), set: jest.fn() } }
+    const spies = {};
     beforeEach(() => {
       hook = hooks.fileInputHooks({ setSelection, clearSelection, imgList });
     });
@@ -257,21 +258,24 @@ describe('SelectImageModal hooks', () => {
       expect(click).toHaveBeenCalled();
     });
     describe('addFile (uploadImage args)', () => {
-      const eventSuccess = { target: { files: [testValue] } };
+      const eventSuccess = { target: { files: [{value: testValue, size: 2000}] } };
       const eventFailure = { target: { files: [testValueInvalidImage] } };
       it('image fails to upload', () => {
-        const spies = {};
         const onSizeFail = jest.fn();
         const checkValidFileSize = false;
         spies.checkValidFileSize = jest.spyOn(hooks, hookKeys.checkValidFileSize)
           .mockReturnValueOnce(checkValidFileSize);
         hook.addFile(eventFailure);
-        expect(spies.checkValidFileSize).toHaveBeenCalledWith({
-          selectedFile:testValueInvalidImage, clearSelection, onSizeFail: () => {onSizeFail}
-        });
+        expect(spies.checkValidFileSize.mock.calls.length).toEqual(1);
+        expect(spies.checkValidFileSize).toHaveReturnedWith(false);
       });
       it('dispatches uploadImage thunkAction with the first target file and setSelection', () => {
+        const checkValidFileSize = true;
+        spies.checkValidFileSize = jest.spyOn(hooks, hookKeys.checkValidFileSize)
+          .mockReturnValueOnce(checkValidFileSize);
         hook.addFile(eventSuccess);
+        expect(spies.checkValidFileSize.mock.calls.length).toEqual(1);
+        expect(spies.checkValidFileSize).toHaveReturnedWith(true);
         expect(dispatch).toHaveBeenCalledWith(thunkActions.app.uploadImage({
           file: testValue,
           setSelection,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -320,7 +320,7 @@ describe('SelectImageModal hooks', () => {
       expect(hook.searchSortProps).toEqual(searchAndSortHooks);
       expect(spies.file.mock.calls.length).toEqual(1);
       expect(spies.file).toHaveBeenCalledWith({
-        setSelection, clearSelection, imgList: imgListHooks
+        setSelection, clearSelection, imgList: imgListHooks,
       });
     });
     it('forwards galleryProps and selectBtnProps from the image list hooks', () => {

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -243,19 +243,19 @@ describe('SelectImageModal hooks', () => {
   });
   describe('checkValidFileSize', () => {
     const selectedFileFail = testValueInvalidImage;
-    const selectedFileSuccess = { value: testValue, size: 2000 }
+    const selectedFileSuccess = { value: testValue, size: 2000 };
     const clearSelection = jest.fn();
     const onSizeFail = jest.fn();
     it('returns false for valid file size ', () => {
-      hook = hooks.checkValidFileSize({ selectedFile: selectedFileFail, clearSelection, onSizeFail});
+      hook = hooks.checkValidFileSize({ selectedFile: selectedFileFail, clearSelection, onSizeFail });
       expect(clearSelection).toHaveBeenCalled();
       expect(onSizeFail).toHaveBeenCalled();
       expect(hook).toEqual(false);
     });
     it('returns true for valid file size', () => {
-      hook = hooks.checkValidFileSize({ selectedFile: selectedFileSuccess, clearSelection, onSizeFail});
+      hook = hooks.checkValidFileSize({ selectedFile: selectedFileSuccess, clearSelection, onSizeFail });
       expect(hook).toEqual(true);
-    })
+    });
   });
   describe('fileInputHooks', () => {
     const setSelection = jest.fn();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -55,7 +55,7 @@ const state = new MockUseState(hooks);
 const hookKeys = keyStore(hooks);
 let hook;
 const testValue = 'testVALUEVALIDIMAGE';
-const testValueInvalidImage = {value:'testVALUEVALIDIMAGE', size: 90000000}
+const testValueInvalidImage = {;value:'testVALUEVALIDIMAGE', size: 90000000 };
 
 describe('SelectImageModal hooks', () => {
   beforeEach(() => {
@@ -242,7 +242,7 @@ describe('SelectImageModal hooks', () => {
   describe('fileInputHooks', () => {
     const setSelection = jest.fn();
     const clearSelection = jest.fn();
-    const imgList = {inputError: {show:true, dismiss:jest.fn(), set:jest.fn()}}
+    const imgList = { inputError: { show: true, dismiss: jest.fn(), set: jest.fn() } }
     beforeEach(() => {
       hook = hooks.fileInputHooks({ setSelection, clearSelection, imgList });
     });
@@ -259,15 +259,17 @@ describe('SelectImageModal hooks', () => {
     describe('addFile (uploadImage args)', () => {
       const eventSuccess = { target: { files: [testValue] } };
       const eventFailure = { target: { files: [testValueInvalidImage] } };
-      it ('image fails to upload', () => {
+      it('image fails to upload', () => {
         const spies = {};
         const onSizeFail = jest.fn();
         const checkValidFileSize = false;
         spies.checkValidFileSize = jest.spyOn(hooks, hookKeys.checkValidFileSize)
           .mockReturnValueOnce(checkValidFileSize);
         hook.addFile(eventFailure);
-        expect(spies.checkValidFileSize).toHaveBeenCalledWith({selectedFile:testValueInvalidImage, clearSelection, onSizeFail: () => {onSizeFail}});
-      })
+        expect(spies.checkValidFileSize).toHaveBeenCalledWith({
+          selectedFile:testValueInvalidImage, clearSelection, onSizeFail: () => {onSizeFail}
+        });
+      });
       it('dispatches uploadImage thunkAction with the first target file and setSelection', () => {
         hook.addFile(eventSuccess);
         expect(dispatch).toHaveBeenCalledWith(thunkActions.app.uploadImage({
@@ -298,11 +300,10 @@ describe('SelectImageModal hooks', () => {
       hook = hooks.imgHooks({ setSelection, clearSelection });
     });
     it('forwards fileInputHooks as fileInput, called with uploadImage prop', () => {
-      const imgList = imgListHooks
       expect(hook.fileInput).toEqual(fileInputHooks);
       expect(spies.file.mock.calls.length).toEqual(1);
       expect(spies.file).toHaveBeenCalledWith({
-        setSelection, clearSelection, imgList,
+        setSelection, clearSelection, imgList:imgListHooks,
       });
     });
     it('initializes imgListHooks with setSelection and searchAndSortHooks', () => {
@@ -313,11 +314,9 @@ describe('SelectImageModal hooks', () => {
       });
     });
     it('forwards searchAndSortHooks as searchSortProps', () => {
-      const imgList = imgListHooks
       expect(hook.searchSortProps).toEqual(searchAndSortHooks);
       expect(spies.file.mock.calls.length).toEqual(1);
-      expect(spies.file).toHaveBeenCalledWith({ setSelection, clearSelection, imgList,
-       });
+      expect(spies.file).toHaveBeenCalledWith({ setSelection, clearSelection, imgList:imgListHooks });
     });
     it('forwards galleryProps and selectBtnProps from the image list hooks', () => {
       expect(hook.galleryProps).toEqual(imgListHooks.galleryProps);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -278,7 +278,7 @@ describe('SelectImageModal hooks', () => {
     describe('addFile (uploadImage args)', () => {
       const eventSuccess = { target: { files: [{ value: testValue, size: 2000 }] } };
       const eventFailure = { target: { files: [testValueInvalidImage] } };
-      it('image fails to upload', () => {
+      it('image fails to upload if file size is greater than 1000000', () => {
         const checkValidFileSize = false;
         spies.checkValidFileSize = jest.spyOn(hooks, hookKeys.checkValidFileSize)
           .mockReturnValueOnce(checkValidFileSize);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -55,7 +55,7 @@ const state = new MockUseState(hooks);
 const hookKeys = keyStore(hooks);
 let hook;
 const testValue = 'testVALUEVALIDIMAGE';
-const testValueInvalidImage = { value:'testVALUEVALIDIMAGE', size: 90000000 };
+const testValueInvalidImage = { value: 'testVALUEVALIDIMAGE', size: 90000000 };
 
 describe('SelectImageModal hooks', () => {
   beforeEach(() => {
@@ -242,7 +242,7 @@ describe('SelectImageModal hooks', () => {
   describe('fileInputHooks', () => {
     const setSelection = jest.fn();
     const clearSelection = jest.fn();
-    const imgList = { inputError: { show: true, dismiss: jest.fn(), set: jest.fn() } }
+    const imgList = { inputError: { show: true, dismiss: jest.fn(), set: jest.fn() } };
     const spies = {};
     beforeEach(() => {
       hook = hooks.fileInputHooks({ setSelection, clearSelection, imgList });
@@ -258,10 +258,9 @@ describe('SelectImageModal hooks', () => {
       expect(click).toHaveBeenCalled();
     });
     describe('addFile (uploadImage args)', () => {
-      const eventSuccess = { target: { files: [{value: testValue, size: 2000}] } };
+      const eventSuccess = { target: { files: [{ value: testValue, size: 2000 }] } };
       const eventFailure = { target: { files: [testValueInvalidImage] } };
       it('image fails to upload', () => {
-        const onSizeFail = jest.fn();
         const checkValidFileSize = false;
         spies.checkValidFileSize = jest.spyOn(hooks, hookKeys.checkValidFileSize)
           .mockReturnValueOnce(checkValidFileSize);
@@ -307,7 +306,7 @@ describe('SelectImageModal hooks', () => {
       expect(hook.fileInput).toEqual(fileInputHooks);
       expect(spies.file.mock.calls.length).toEqual(1);
       expect(spies.file).toHaveBeenCalledWith({
-        setSelection, clearSelection, imgList:imgListHooks,
+        setSelection, clearSelection, imgList: imgListHooks,
       });
     });
     it('initializes imgListHooks with setSelection and searchAndSortHooks', () => {
@@ -320,7 +319,9 @@ describe('SelectImageModal hooks', () => {
     it('forwards searchAndSortHooks as searchSortProps', () => {
       expect(hook.searchSortProps).toEqual(searchAndSortHooks);
       expect(spies.file.mock.calls.length).toEqual(1);
-      expect(spies.file).toHaveBeenCalledWith({ setSelection, clearSelection, imgList:imgListHooks });
+      expect(spies.file).toHaveBeenCalledWith({
+        setSelection, clearSelection, imgList: imgListHooks
+      });
     });
     it('forwards galleryProps and selectBtnProps from the image list hooks', () => {
       expect(hook.galleryProps).toEqual(imgListHooks.galleryProps);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -67,6 +67,7 @@ describe('SelectImageModal hooks', () => {
     state.testGetter(state.keys.showSelectImageError);
     state.testGetter(state.keys.searchString);
     state.testGetter(state.keys.sortBy);
+    state.testGetter(state.keys.showSizeError);
   });
 
   describe('using state', () => {
@@ -123,6 +124,7 @@ describe('SelectImageModal hooks', () => {
         images: { p1: 'data1', p2: 'data2', p3: 'other distinct data' },
         sortBy: sortKeys.dateNewest,
         searchString: 'test search string',
+
       };
       const load = (loadProps = {}) => {
         jest.spyOn(hooks, hookKeys.filteredList).mockImplementationOnce(
@@ -211,7 +213,7 @@ describe('SelectImageModal hooks', () => {
           }));
         });
       });
-      describe('error', () => {
+      describe('galleryError', () => {
         test('show is initialized to false and returns properly', () => {
           const show = 'sHOWSelectiMaGEeRROr';
           expect(hook.galleryError.show).toEqual(false);
@@ -238,6 +240,22 @@ describe('SelectImageModal hooks', () => {
         // });
       });
     });
+  });
+  describe('checkValidFileSize', () => {
+    const selectedFileFail = testValueInvalidImage;
+    const selectedFileSuccess = { value: testValue, size: 2000 }
+    const clearSelection = jest.fn();
+    const onSizeFail = jest.fn();
+    it('returns false for valid file size ', () => {
+      hook = hooks.checkValidFileSize({ selectedFile: selectedFileFail, clearSelection, onSizeFail});
+      expect(clearSelection).toHaveBeenCalled();
+      expect(onSizeFail).toHaveBeenCalled();
+      expect(hook).toEqual(false);
+    });
+    it('returns true for valid file size', () => {
+      hook = hooks.checkValidFileSize({ selectedFile: selectedFileSuccess, clearSelection, onSizeFail});
+      expect(hook).toEqual(true);
+    })
   });
   describe('fileInputHooks', () => {
     const setSelection = jest.fn();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -102,9 +102,8 @@ SelectImageModal.propTypes = {
   inputIsLoading: PropTypes.bool.isRequired,
 };
 
-const requestKey = RequestKeys.uploadImage;
 export const mapStateToProps = (state) => ({
-  inputIsLoading: selectors.requests.isPending(state, { requestKey }),
+  inputIsLoading: selectors.requests.isPending(state, { RequestKeys.uploadImage }),
 });
 
 export const mapDispatchToProps = {};

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { connect } from 'react-redux';
 import PropTypes from "prop-types";
 
 import { Button, Stack, Spinner } from "@edx/paragon";
@@ -30,7 +31,6 @@ export const SelectImageModal = ({
   intl,
   // redux
   inputIsLoading,
-  inputIsLoaded,
 }) => {
   const {
     galleryError,
@@ -78,15 +78,15 @@ export const SelectImageModal = ({
       </ErrorAlert>
       <Stack gap={3}>
         <SearchSort {...searchSortProps} />
-        <Gallery {...galleryProps} />
-        <FileInput fileInput={fileInput} />
-        {!inputIsLoading ? null : (
+        {!inputIsLoading ?
+          <Gallery {...galleryProps} /> : (
           <Spinner
-            animation="border"
-            className="mie-3"
-            screenReaderText={intl.formatMessage(messages.loading)}
+          animation="border"
+          className="mie-3"
+          screenReaderText={intl.formatMessage(messages.loading)}
           />
         )}
+        <FileInput fileInput={fileInput} />
       </Stack>
     </BaseModal>
   );
@@ -101,11 +101,10 @@ SelectImageModal.propTypes = {
 };
 
 const requestKey = RequestKeys.uploadImage;
-export const maptStateToProps = (state) => ({
+export const mapStateToProps = (state) => ({
   inputIsLoading: selectors.requests.isPending(state, { requestKey }),
-  inputIsLoaded: selectors.requests.isComplete(state, { requestKey }),
 });
 
 export const mapDispatchToProps = {};
 
-export default injectIntl(SelectImageModal);
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(SelectImageModal));

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -103,7 +103,7 @@ SelectImageModal.propTypes = {
 };
 
 export const mapStateToProps = (state) => ({
-  inputIsLoading: selectors.requests.isPending(state, { RequestKeys.uploadImage }),
+  inputIsLoading: selectors.requests.isPending(state, { requestKey: RequestKeys.uploadImage }),
 });
 
 export const mapDispatchToProps = {};

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -1,26 +1,26 @@
-import React from "react";
+import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types';
 
-import { Button, Stack, Spinner } from "@edx/paragon";
-import { Add } from "@edx/paragon/icons";
+import { Button, Stack, Spinner } from '@edx/paragon';
+import { Add } from '@edx/paragon/icons';
 import {
   FormattedMessage,
   injectIntl,
   intlShape,
-} from "@edx/frontend-platform/i18n";
-import { selectors } from "../../../../data/redux";
-import { RequestKeys } from "../../../../data/constants/requests";
+} from '@edx/frontend-platform/i18n';
+import { selectors } from '../../../../data/redux';
+import { RequestKeys } from '../../../../data/constants/requests';
 
-import hooks from "./hooks";
-import messages from "./messages";
-import BaseModal from "../BaseModal";
-import SearchSort from "./SearchSort";
-import Gallery from "./Gallery";
-import FileInput from "./FileInput";
-import FetchErrorAlert from "../ErrorAlerts/FetchErrorAlert";
-import UploadErrorAlert from "../ErrorAlerts/UploadErrorAlert";
-import ErrorAlert from "../ErrorAlerts/ErrorAlert";
+import hooks from './hooks';
+import messages from './messages';
+import BaseModal from '../BaseModal';
+import SearchSort from './SearchSort';
+import Gallery from './Gallery';
+import FileInput from './FileInput';
+import FetchErrorAlert from '../ErrorAlerts/FetchErrorAlert';
+import UploadErrorAlert from '../ErrorAlerts/UploadErrorAlert';
+import ErrorAlert from '../ErrorAlerts/ErrorAlert';
 
 export const SelectImageModal = ({
   isOpen,
@@ -44,17 +44,17 @@ export const SelectImageModal = ({
   return (
     <BaseModal
       close={close}
-      confirmAction={
+      confirmAction={(
         <Button {...selectBtnProps} variant="primary">
           <FormattedMessage {...messages.nextButtonLabel} />
         </Button>
-      }
+      )}
       isOpen={isOpen}
-      footerAction={
+      footerAction={(
         <Button iconBefore={Add} onClick={fileInput.click} variant="link">
           <FormattedMessage {...messages.uploadButtonLabel} />
         </Button>
-      }
+      )}
       title={intl.formatMessage(messages.titleLabel)}
     >
       {/* Error Alerts */}
@@ -78,12 +78,11 @@ export const SelectImageModal = ({
       </ErrorAlert>
       <Stack gap={3}>
         <SearchSort {...searchSortProps} />
-        {!inputIsLoading ?
-          <Gallery {...galleryProps} /> : (
+        {!inputIsLoading ? <Gallery {...galleryProps} /> : (
           <Spinner
-          animation="border"
-          className="mie-3"
-          screenReaderText={intl.formatMessage(messages.loading)}
+            animation="border"
+            className="mie-3"
+            screenReaderText={intl.formatMessage(messages.loading)}
           />
         )}
         <FileInput fileInput={fileInput} />
@@ -96,8 +95,11 @@ SelectImageModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
   setSelection: PropTypes.func.isRequired,
+  clearSelection: PropTypes.func.isRequired,
   // injected
   intl: intlShape.isRequired,
+  // redux
+  inputIsLoading: PropTypes.bool.isRequired,
 };
 
 const requestKey = RequestKeys.uploadImage;

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -1,71 +1,94 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-import { Button, Stack } from '@edx/paragon';
-import { Add } from '@edx/paragon/icons';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Button, Stack, Spinner } from "@edx/paragon";
+import { Add } from "@edx/paragon/icons";
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from "@edx/frontend-platform/i18n";
+import { selectors } from "../../../../data/redux";
+import { RequestKeys } from "../../../../data/constants/requests";
 
-import hooks from './hooks';
-import messages from './messages';
-import BaseModal from '../BaseModal';
-import SearchSort from './SearchSort';
-import Gallery from './Gallery';
-import FileInput from './FileInput';
-import FetchErrorAlert from '../ErrorAlerts/FetchErrorAlert';
-import UploadErrorAlert from '../ErrorAlerts/UploadErrorAlert';
-import ErrorAlert from '../ErrorAlerts/ErrorAlert';
+import hooks from "./hooks";
+import messages from "./messages";
+import BaseModal from "../BaseModal";
+import SearchSort from "./SearchSort";
+import Gallery from "./Gallery";
+import FileInput from "./FileInput";
+import FetchErrorAlert from "../ErrorAlerts/FetchErrorAlert";
+import UploadErrorAlert from "../ErrorAlerts/UploadErrorAlert";
+import ErrorAlert from "../ErrorAlerts/ErrorAlert";
 
 export const SelectImageModal = ({
   isOpen,
   close,
   setSelection,
+  clearSelection,
   // injected
   intl,
+  // redux
+  inputIsLoading,
+  inputIsLoaded,
 }) => {
   const {
-    error,
+    galleryError,
+    inputError,
     fileInput,
     galleryProps,
     searchSortProps,
     selectBtnProps,
-  } = hooks.imgHooks({ setSelection });
+  } = hooks.imgHooks({ setSelection, clearSelection });
+
   return (
     <BaseModal
       close={close}
-      confirmAction={(
+      confirmAction={
         <Button {...selectBtnProps} variant="primary">
           <FormattedMessage {...messages.nextButtonLabel} />
         </Button>
-      )}
+      }
       isOpen={isOpen}
-      footerAction={(
+      footerAction={
         <Button iconBefore={Add} onClick={fileInput.click} variant="link">
           <FormattedMessage {...messages.uploadButtonLabel} />
         </Button>
-      )}
+      }
       title={intl.formatMessage(messages.titleLabel)}
     >
-
       {/* Error Alerts */}
       <FetchErrorAlert />
       <UploadErrorAlert />
+      <ErrorAlert
+        dismissError={inputError.dismiss}
+        hideHeading
+        isError={inputError.show}
+      >
+        <FormattedMessage {...messages.fileSizeError} />
+      </ErrorAlert>
 
       {/* User Feedback Alerts */}
       <ErrorAlert
-        dismissError={error.dismiss}
+        dismissError={galleryError.dismiss}
         hideHeading
-        isError={error.show}
+        isError={galleryError.show}
       >
         <FormattedMessage {...messages.selectImageError} />
       </ErrorAlert>
-
       <Stack gap={3}>
         <SearchSort {...searchSortProps} />
         <Gallery {...galleryProps} />
         <FileInput fileInput={fileInput} />
+        {!inputIsLoading ? null : (
+          <Spinner
+            animation="border"
+            className="mie-3"
+            screenReaderText={intl.formatMessage(messages.loading)}
+          />
+        )}
       </Stack>
     </BaseModal>
-
   );
 };
 
@@ -76,5 +99,13 @@ SelectImageModal.propTypes = {
   // injected
   intl: intlShape.isRequired,
 };
+
+const requestKey = RequestKeys.uploadImage;
+export const maptStateToProps = (state) => ({
+  inputIsLoading: selectors.requests.isPending(state, { requestKey }),
+  inputIsLoaded: selectors.requests.isComplete(state, { requestKey }),
+});
+
+export const mapDispatchToProps = {};
 
 export default injectIntl(SelectImageModal);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -15,11 +15,17 @@ jest.mock('./Gallery', () => 'Gallery');
 jest.mock('./SearchSort', () => 'SearchSort');
 jest.mock('../ErrorAlerts/FetchErrorAlert', () => 'FetchErrorAlert');
 jest.mock('../ErrorAlerts/UploadErrorAlert', () => 'UploadErrorAlert');
+jest.mock('../ErrorAlerts/ErrorAlert', () => 'ErrorAlert');
 
 jest.mock('./hooks', () => ({
   imgHooks: jest.fn(() => ({
-    error: {
-      show: 'ShoWERror',
+    galleryError: {
+      show: 'ShoWERror gAlLery',
+      set: jest.fn(),
+      dismiss: jest.fn(),
+    },
+    inputError: {
+      show: 'ShoWERror inPUT',
       set: jest.fn(),
       dismiss: jest.fn(),
     },

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -69,7 +69,9 @@ describe('SelectImageModal', () => {
       expect(el).toMatchSnapshot();
     });
     test('snapshot: uploaded image not loaded, show spinner', () => {
-      expect(shallow(<SelectImageModal {...props} inputIsLoading={true} />)).toMatchSnapshot();
+      props.inputIsLoading = true;
+      expect(shallow(<SelectImageModal { ...props } />)).toMatchSnapshot();
+      props.inputIsLoading = false;
     });
     it('provides confirm action, forwarding selectBtnProps from imgHooks', () => {
       expect(el.find(BaseModal).props().confirmAction.props).toEqual(

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -70,7 +70,7 @@ describe('SelectImageModal', () => {
     });
     test('snapshot: uploaded image not loaded, show spinner', () => {
       props.inputIsLoading = true;
-      expect(shallow(<SelectImageModal { ...props } />)).toMatchSnapshot();
+      expect(shallow(<SelectImageModal {...props} />)).toMatchSnapshot();
       props.inputIsLoading = false;
     });
     it('provides confirm action, forwarding selectBtnProps from imgHooks', () => {

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -69,7 +69,7 @@ describe('SelectImageModal', () => {
       expect(el).toMatchSnapshot();
     });
     test('snapshot: uploaded image not loaded, show spinner', () => {
-      expect(shallow(<SelectImageModal {...props} isLoaded={false} />)).toMatchSnapshot();
+      expect(shallow(<SelectImageModal {...props} isLoaded={true} />)).toMatchSnapshot();
     });
     it('provides confirm action, forwarding selectBtnProps from imgHooks', () => {
       expect(el.find(BaseModal).props().confirmAction.props).toEqual(

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -69,7 +69,7 @@ describe('SelectImageModal', () => {
       expect(el).toMatchSnapshot();
     });
     test('snapshot: uploaded image not loaded, show spinner', () => {
-      expect(shallow(<SelectImageModal {...props} isLoaded={true} />)).toMatchSnapshot();
+      expect(shallow(<SelectImageModal {...props} inputIsLoading={true} />)).toMatchSnapshot();
     });
     it('provides confirm action, forwarding selectBtnProps from imgHooks', () => {
       expect(el.find(BaseModal).props().confirmAction.props).toEqual(

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.test.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { formatMessage } from '../../../../../testUtils';
+import { RequestKeys } from '../../../../data/constants/requests';
+import { selectors } from '../../../../data/redux';
 import BaseModal from '../BaseModal';
 import FileInput from './FileInput';
 import Gallery from './Gallery';
 import SearchSort from './SearchSort';
 import hooks from './hooks';
-import { SelectImageModal } from '.';
+import { SelectImageModal, mapStateToProps, mapDispatchToProps } from '.';
 
 jest.mock('../BaseModal', () => 'BaseModal');
 jest.mock('./FileInput', () => 'FileInput');
@@ -40,13 +42,23 @@ jest.mock('./hooks', () => ({
   })),
 }));
 
+jest.mock('../../../../data/redux', () => ({
+  selectors: {
+    requests: {
+      isPending: (state, { requestKey }) => ({ isPending: { state, requestKey } }),
+    },
+  },
+}));
+
 describe('SelectImageModal', () => {
   describe('component', () => {
     const props = {
       isOpen: true,
       close: jest.fn().mockName('props.close'),
       setSelection: jest.fn().mockName('props.setSelection'),
+      clearSelection: jest.fn().mockName('props.clearSelection'),
       intl: { formatMessage },
+      inputIsLoading: false,
     };
     let el;
     const imgHooks = hooks.imgHooks();
@@ -55,6 +67,9 @@ describe('SelectImageModal', () => {
     });
     test('snapshot', () => {
       expect(el).toMatchSnapshot();
+    });
+    test('snapshot: uploaded image not loaded, show spinner', () => {
+      expect(shallow(<SelectImageModal {...props} isLoaded={false} />)).toMatchSnapshot();
     });
     it('provides confirm action, forwarding selectBtnProps from imgHooks', () => {
       expect(el.find(BaseModal).props().confirmAction.props).toEqual(
@@ -74,6 +89,19 @@ describe('SelectImageModal', () => {
     });
     it('provides a FileInput component with fileInput props from imgHooks', () => {
       expect(el.find(FileInput).props()).toMatchObject({ fileInput: imgHooks.fileInput });
+    });
+  });
+  describe('mapStateToProps', () => {
+    const testState = { some: 'testState' };
+    test('loads inputIsLoading from requests.isPending selector for uploadImage request', () => {
+      expect(mapStateToProps(testState).inputIsLoading).toEqual(
+        selectors.requests.isPending(testState, { requestKey: RequestKeys.uploadImage }),
+      );
+    });
+  });
+  describe('mapDispatchToProps', () => {
+    test('is empty', () => {
+      expect(mapDispatchToProps).toEqual({});
     });
   });
 });

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -6,7 +6,7 @@ export const messages = {
   },
   uploadButtonLabel: {
     id: 'authoring.texteditor.selectimagemodal.upload.label',
-    defaultMessage: 'Upload a new image',
+    defaultMessage: 'Upload a new image (10 MB max)',
     description: 'Label for upload button',
   },
   titleLabel: {
@@ -72,7 +72,7 @@ export const messages = {
   },
   uploadImageError: {
     id: 'authoring.texteditor.selectimagemodal.error.uploadImageError',
-    defaultMessage: 'Failed to Upload Image. Please Try again.',
+    defaultMessage: 'Failed to upload image. Please try again.',
     description: 'Message presented to user when image fails to upload',
   },
   fetchImagesError: {

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -84,7 +84,7 @@ export const messages = {
   fileSizeError: {
     id: "authoring.texteditor.selectimagemodal.error.fileSizeError",
     defaultMessage:
-      "Selected image exceed the maximum file size, 10 MB. Please resize image and try again.",
+      "Images must be 10 MB or less. Please resize image and try again.",
     description:
       " Message presented to user when file size of image is larger than 10 MB",
   },

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -1,98 +1,98 @@
 export const messages = {
   nextButtonLabel: {
-    id: "authoring.texteditor.selectimagemodal.next.label",
-    defaultMessage: "Next",
-    description: "Label for Next button",
+    id: 'authoring.texteditor.selectimagemodal.next.label',
+    defaultMessage: 'Next',
+    description: 'Label for Next button',
   },
   uploadButtonLabel: {
-    id: "authoring.texteditor.selectimagemodal.upload.label",
-    defaultMessage: "Upload a new image (10 MB max)",
-    description: "Label for upload button",
+    id: 'authoring.texteditor.selectimagemodal.upload.label',
+    defaultMessage: 'Upload a new image (10 MB max)',
+    description: 'Label for upload button',
   },
   titleLabel: {
-    id: "authoring.texteditor.selectimagemodal.title.label",
-    defaultMessage: "Add an image",
-    description: "Title for the select image modal",
+    id: 'authoring.texteditor.selectimagemodal.title.label',
+    defaultMessage: 'Add an image',
+    description: 'Title for the select image modal',
   },
   searchPlaceholder: {
-    id: "authoring.texteditor.selectimagemodal.search.placeholder",
-    defaultMessage: "Search",
-    description: "Placeholder text for search bar",
+    id: 'authoring.texteditor.selectimagemodal.search.placeholder',
+    defaultMessage: 'Search',
+    description: 'Placeholder text for search bar',
   },
 
   // Sort Dropdown
   sortByDateNewest: {
-    id: "authoring.texteditor.selectimagemodal.sort.datenewest.label",
-    defaultMessage: "By date added (newest)",
-    description: "Dropdown label for sorting by date (newest)",
+    id: 'authoring.texteditor.selectimagemodal.sort.datenewest.label',
+    defaultMessage: 'By date added (newest)',
+    description: 'Dropdown label for sorting by date (newest)',
   },
   sortByDateOldest: {
-    id: "authoring.texteditor.selectimagemodal.sort.dateoldest.label",
-    defaultMessage: "By date added (oldest)",
-    description: "Dropdown label for sorting by date (oldest)",
+    id: 'authoring.texteditor.selectimagemodal.sort.dateoldest.label',
+    defaultMessage: 'By date added (oldest)',
+    description: 'Dropdown label for sorting by date (oldest)',
   },
   sortByNameAscending: {
-    id: "authoring.texteditor.selectimagemodal.sort.nameascending.label",
-    defaultMessage: "By name (ascending)",
-    description: "Dropdown label for sorting by name (ascending)",
+    id: 'authoring.texteditor.selectimagemodal.sort.nameascending.label',
+    defaultMessage: 'By name (ascending)',
+    description: 'Dropdown label for sorting by name (ascending)',
   },
   sortByNameDescending: {
-    id: "authoring.texteditor.selectimagemodal.sort.namedescending.label",
-    defaultMessage: "By name (descending)",
-    description: "Dropdown label for sorting by name (descending)",
+    id: 'authoring.texteditor.selectimagemodal.sort.namedescending.label',
+    defaultMessage: 'By name (descending)',
+    description: 'Dropdown label for sorting by name (descending)',
   },
 
   // Gallery
   addedDate: {
-    id: "authoring.texteditor.selectimagemodal.addedDate.label",
-    defaultMessage: "Added {date} at {time}",
-    description: "File date-added string",
+    id: 'authoring.texteditor.selectimagemodal.addedDate.label',
+    defaultMessage: 'Added {date} at {time}',
+    description: 'File date-added string',
   },
   loading: {
-    id: "authoring.texteditor.selectimagemodal.spinner.readertext",
-    defaultMessage: "loading...",
-    description: "Gallery loading spinner screen-reader text",
+    id: 'authoring.texteditor.selectimagemodal.spinner.readertext',
+    defaultMessage: 'loading...',
+    description: 'Gallery loading spinner screen-reader text',
   },
   emptyGalleryLabel: {
-    id: "authoring.texteditor.selectimagemodal.emptyGalleryLabel",
+    id: 'authoring.texteditor.selectimagemodal.emptyGalleryLabel',
     defaultMessage:
-      "No images found in your gallery. Please upload an image using the button below.",
-    description: "Label for when image gallery is empty.",
+      'No images found in your gallery. Please upload an image using the button below.',
+    description: 'Label for when image gallery is empty.',
   },
   emptySearchLabel: {
-    id: "authoring.texteditor.selectimagemodal.emptySearchLabel",
-    defaultMessage: "No search results.",
-    description: "Label for when search returns nothing.",
+    id: 'authoring.texteditor.selectimagemodal.emptySearchLabel',
+    defaultMessage: 'No search results.',
+    description: 'Label for when search returns nothing.',
   },
 
   // Errors
   errorTitle: {
-    id: "authoring.texteditor.selectimagemodal.error.errorTitle",
-    defaultMessage: "Error",
-    description: "Title of message presented to user when something goes wrong",
+    id: 'authoring.texteditor.selectimagemodal.error.errorTitle',
+    defaultMessage: 'Error',
+    description: 'Title of message presented to user when something goes wrong',
   },
   uploadImageError: {
-    id: "authoring.texteditor.selectimagemodal.error.uploadImageError",
-    defaultMessage: "Failed to upload image. Please try again.",
-    description: "Message presented to user when image fails to upload",
+    id: 'authoring.texteditor.selectimagemodal.error.uploadImageError',
+    defaultMessage: 'Failed to upload image. Please try again.',
+    description: 'Message presented to user when image fails to upload',
   },
   fetchImagesError: {
-    id: "authoring.texteditor.selectimagemodal.error.fetchImagesError",
-    defaultMessage: "Failed to obtain course images. Please try again.",
-    description: "Message presented to user when images are not found",
+    id: 'authoring.texteditor.selectimagemodal.error.fetchImagesError',
+    defaultMessage: 'Failed to obtain course images. Please try again.',
+    description: 'Message presented to user when images are not found',
   },
   fileSizeError: {
-    id: "authoring.texteditor.selectimagemodal.error.fileSizeError",
+    id: 'authoring.texteditor.selectimagemodal.error.fileSizeError',
     defaultMessage:
-      "Images must be 10 MB or less. Please resize image and try again.",
+      'Images must be 10 MB or less. Please resize image and try again.',
     description:
-      " Message presented to user when file size of image is larger than 10 MB",
+      ' Message presented to user when file size of image is larger than 10 MB',
   },
   selectImageError: {
-    id: "authoring.texteditor.selectimagemodal.error.selectImageError",
-    defaultMessage: "Select an image to continue.",
+    id: 'authoring.texteditor.selectimagemodal.error.selectImageError',
+    defaultMessage: 'Select an image to continue.',
     description:
-      "Message presented to user when clicking Next without selecting an image",
+      'Message presented to user when clicking Next without selecting an image',
   },
 };
 

--- a/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/messages.js
@@ -1,89 +1,98 @@
 export const messages = {
   nextButtonLabel: {
-    id: 'authoring.texteditor.selectimagemodal.next.label',
-    defaultMessage: 'Next',
-    description: 'Label for Next button',
+    id: "authoring.texteditor.selectimagemodal.next.label",
+    defaultMessage: "Next",
+    description: "Label for Next button",
   },
   uploadButtonLabel: {
-    id: 'authoring.texteditor.selectimagemodal.upload.label',
-    defaultMessage: 'Upload a new image (10 MB max)',
-    description: 'Label for upload button',
+    id: "authoring.texteditor.selectimagemodal.upload.label",
+    defaultMessage: "Upload a new image (10 MB max)",
+    description: "Label for upload button",
   },
   titleLabel: {
-    id: 'authoring.texteditor.selectimagemodal.title.label',
-    defaultMessage: 'Add an image',
-    description: 'Title for the select image modal',
+    id: "authoring.texteditor.selectimagemodal.title.label",
+    defaultMessage: "Add an image",
+    description: "Title for the select image modal",
   },
   searchPlaceholder: {
-    id: 'authoring.texteditor.selectimagemodal.search.placeholder',
-    defaultMessage: 'Search',
-    description: 'Placeholder text for search bar',
+    id: "authoring.texteditor.selectimagemodal.search.placeholder",
+    defaultMessage: "Search",
+    description: "Placeholder text for search bar",
   },
 
   // Sort Dropdown
   sortByDateNewest: {
-    id: 'authoring.texteditor.selectimagemodal.sort.datenewest.label',
-    defaultMessage: 'By date added (newest)',
-    description: 'Dropdown label for sorting by date (newest)',
+    id: "authoring.texteditor.selectimagemodal.sort.datenewest.label",
+    defaultMessage: "By date added (newest)",
+    description: "Dropdown label for sorting by date (newest)",
   },
   sortByDateOldest: {
-    id: 'authoring.texteditor.selectimagemodal.sort.dateoldest.label',
-    defaultMessage: 'By date added (oldest)',
-    description: 'Dropdown label for sorting by date (oldest)',
+    id: "authoring.texteditor.selectimagemodal.sort.dateoldest.label",
+    defaultMessage: "By date added (oldest)",
+    description: "Dropdown label for sorting by date (oldest)",
   },
   sortByNameAscending: {
-    id: 'authoring.texteditor.selectimagemodal.sort.nameascending.label',
-    defaultMessage: 'By name (ascending)',
-    description: 'Dropdown label for sorting by name (ascending)',
+    id: "authoring.texteditor.selectimagemodal.sort.nameascending.label",
+    defaultMessage: "By name (ascending)",
+    description: "Dropdown label for sorting by name (ascending)",
   },
   sortByNameDescending: {
-    id: 'authoring.texteditor.selectimagemodal.sort.namedescending.label',
-    defaultMessage: 'By name (descending)',
-    description: 'Dropdown label for sorting by name (descending)',
+    id: "authoring.texteditor.selectimagemodal.sort.namedescending.label",
+    defaultMessage: "By name (descending)",
+    description: "Dropdown label for sorting by name (descending)",
   },
 
   // Gallery
   addedDate: {
-    id: 'authoring.texteditor.selectimagemodal.addedDate.label',
-    defaultMessage: 'Added {date} at {time}',
-    description: 'File date-added string',
+    id: "authoring.texteditor.selectimagemodal.addedDate.label",
+    defaultMessage: "Added {date} at {time}",
+    description: "File date-added string",
   },
   loading: {
-    id: 'authoring.texteditor.selectimagemodal.spinner.readertext',
-    defaultMessage: 'loading...',
-    description: 'Gallery loading spinner screen-reader text',
+    id: "authoring.texteditor.selectimagemodal.spinner.readertext",
+    defaultMessage: "loading...",
+    description: "Gallery loading spinner screen-reader text",
   },
   emptyGalleryLabel: {
-    id: 'authoring.texteditor.selectimagemodal.emptyGalleryLabel',
-    defaultMessage: 'No images found in your gallery. Please upload an image using the button below.',
-    description: 'Label for when image gallery is empty.',
+    id: "authoring.texteditor.selectimagemodal.emptyGalleryLabel",
+    defaultMessage:
+      "No images found in your gallery. Please upload an image using the button below.",
+    description: "Label for when image gallery is empty.",
   },
   emptySearchLabel: {
-    id: 'authoring.texteditor.selectimagemodal.emptySearchLabel',
-    defaultMessage: 'No search results.',
-    description: 'Label for when search returns nothing.',
+    id: "authoring.texteditor.selectimagemodal.emptySearchLabel",
+    defaultMessage: "No search results.",
+    description: "Label for when search returns nothing.",
   },
 
   // Errors
   errorTitle: {
-    id: 'authoring.texteditor.selectimagemodal.error.errorTitle',
-    defaultMessage: 'Error',
-    description: 'Title of message presented to user when something goes wrong',
+    id: "authoring.texteditor.selectimagemodal.error.errorTitle",
+    defaultMessage: "Error",
+    description: "Title of message presented to user when something goes wrong",
   },
   uploadImageError: {
-    id: 'authoring.texteditor.selectimagemodal.error.uploadImageError',
-    defaultMessage: 'Failed to upload image. Please try again.',
-    description: 'Message presented to user when image fails to upload',
+    id: "authoring.texteditor.selectimagemodal.error.uploadImageError",
+    defaultMessage: "Failed to upload image. Please try again.",
+    description: "Message presented to user when image fails to upload",
   },
   fetchImagesError: {
-    id: 'authoring.texteditor.selectimagemodal.error.fetchImagesError',
-    defaultMessage: 'Failed to obtain course Images. Please Try again.',
-    description: 'Message presented to user when images are not found',
+    id: "authoring.texteditor.selectimagemodal.error.fetchImagesError",
+    defaultMessage: "Failed to obtain course images. Please try again.",
+    description: "Message presented to user when images are not found",
+  },
+  fileSizeError: {
+    id: "authoring.texteditor.selectimagemodal.error.fileSizeError",
+    defaultMessage:
+      "Selected image exceed the maximum file size, 10 MB. Please resize image and try again.",
+    description:
+      " Message presented to user when file size of image is larger than 10 MB",
   },
   selectImageError: {
-    id: 'authoring.texteditor.selectimagemodal.error.selectImageError',
-    defaultMessage: 'Select an image to continue.',
-    description: 'Message presented to user when clicking Next without selecting an image',
+    id: "authoring.texteditor.selectimagemodal.error.selectImageError",
+    defaultMessage: "Select an image to continue.",
+    description:
+      "Message presented to user when clicking Next without selecting an image",
   },
 };
 

--- a/src/editors/containers/TextEditor/components/__snapshots__/ImageUploadModal.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/__snapshots__/ImageUploadModal.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ImageUploadModal component snapshot: no selection (Select Image Modal) 1`] = `
 <SelectImageModal
+  clearSelection={[MockFunction props.clearSelection]}
   close={[MockFunction props.close]}
   isOpen={false}
   setSelection={[MockFunction props.setSelection]}

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -1,11 +1,10 @@
-import { StrictDict, camelizeKeys } from "../../../utils";
-import { actions } from "..";
-import * as requests from "./requests";
-import * as module from "./app";
+import { StrictDict, camelizeKeys } from '../../../utils';
+import { actions } from '..';
+import * as requests from './requests';
+import * as module from './app';
 
 export const fetchBlock = () => (dispatch) => {
-  dispatch(
-    requests.fetchBlock({
+  dispatch(requests.fetchBlock({
       onSuccess: (response) => dispatch(actions.app.setBlockValue(response)),
       onFailure: (e) => console.log({ fetchFailure: e }),
     })
@@ -13,8 +12,7 @@ export const fetchBlock = () => (dispatch) => {
 };
 
 export const fetchStudioView = () => (dispatch) => {
-  dispatch(
-    requests.fetchStudioView({
+  dispatch(requests.fetchStudioView({
       onSuccess: (response) => dispatch(actions.app.setStudioView(response)),
       onFailure: (e) => dispatch(actions.app.setStudioView(e)),
     })
@@ -22,8 +20,7 @@ export const fetchStudioView = () => (dispatch) => {
 };
 
 export const fetchUnit = () => (dispatch) => {
-  dispatch(
-    requests.fetchUnit({
+  dispatch(requests.fetchUnit({
       onSuccess: (response) => dispatch(actions.app.setUnitUrl(response)),
       onFailure: (e) => dispatch(actions.app.setUnitUrl(e)),
     })
@@ -48,8 +45,7 @@ export const initialize = (data) => (dispatch) => {
  */
 export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
   dispatch(actions.app.setBlockContent(content));
-  dispatch(
-    requests.saveBlock({
+  dispatch(requests.saveBlock({
       content,
       onSuccess: (response) => {
         dispatch(actions.app.setSaveResponse(response));
@@ -64,8 +60,7 @@ export const fetchImages = ({ setImages }) => (dispatch) => {
 };
 
 export const uploadImage = ({ file, setSelection }) => (dispatch) => {
-  dispatch(
-    requests.uploadImage({
+  dispatch(requests.uploadImage({
       image: file,
       onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),
     })

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -5,26 +5,23 @@ import * as module from './app';
 
 export const fetchBlock = () => (dispatch) => {
   dispatch(requests.fetchBlock({
-      onSuccess: (response) => dispatch(actions.app.setBlockValue(response)),
-      onFailure: (e) => console.log({ fetchFailure: e }),
-    })
-  );
+    onSuccess: (response) => dispatch(actions.app.setBlockValue(response)),
+    onFailure: (e) => console.log({ fetchFailure: e }),
+  }));
 };
 
 export const fetchStudioView = () => (dispatch) => {
   dispatch(requests.fetchStudioView({
-      onSuccess: (response) => dispatch(actions.app.setStudioView(response)),
-      onFailure: (e) => dispatch(actions.app.setStudioView(e)),
-    })
-  );
+    onSuccess: (response) => dispatch(actions.app.setStudioView(response)),
+    onFailure: (e) => dispatch(actions.app.setStudioView(e)),
+  }));
 };
 
 export const fetchUnit = () => (dispatch) => {
   dispatch(requests.fetchUnit({
-      onSuccess: (response) => dispatch(actions.app.setUnitUrl(response)),
-      onFailure: (e) => dispatch(actions.app.setUnitUrl(e)),
-    })
-  );
+    onSuccess: (response) => dispatch(actions.app.setUnitUrl(response)),
+    onFailure: (e) => dispatch(actions.app.setUnitUrl(e)),
+  }));
 };
 
 /**
@@ -46,13 +43,12 @@ export const initialize = (data) => (dispatch) => {
 export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
   dispatch(actions.app.setBlockContent(content));
   dispatch(requests.saveBlock({
-      content,
-      onSuccess: (response) => {
-        dispatch(actions.app.setSaveResponse(response));
-        returnToUnit();
-      },
-    })
-  );
+    content,
+    onSuccess: (response) => {
+      dispatch(actions.app.setSaveResponse(response));
+      returnToUnit();
+    },
+  }));
 };
 
 export const fetchImages = ({ setImages }) => (dispatch) => {
@@ -61,10 +57,9 @@ export const fetchImages = ({ setImages }) => (dispatch) => {
 
 export const uploadImage = ({ file, setSelection }) => (dispatch) => {
   dispatch(requests.uploadImage({
-      image: file,
-      onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),
-    })
-  );
+    image: file,
+    onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),
+  }));
 };
 
 export const fetchVideos = ({ onSuccess }) => (dispatch) => {

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -56,6 +56,10 @@ export const fetchImages = ({ setImages }) => (dispatch) => {
 };
 
 export const uploadImage = ({ file, setSelection }) => (dispatch) => {
+  console.log(file)
+  if (file.size > 10000000) {
+    console.log('image is too big')
+  }
   dispatch(requests.uploadImage({
     image: file,
     onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -1,27 +1,33 @@
-import { StrictDict, camelizeKeys } from '../../../utils';
-import { actions } from '..';
-import * as requests from './requests';
-import * as module from './app';
+import { StrictDict, camelizeKeys } from "../../../utils";
+import { actions } from "..";
+import * as requests from "./requests";
+import * as module from "./app";
 
 export const fetchBlock = () => (dispatch) => {
-  dispatch(requests.fetchBlock({
-    onSuccess: (response) => dispatch(actions.app.setBlockValue(response)),
-    onFailure: (e) => console.log({ fetchFailure: e }),
-  }));
+  dispatch(
+    requests.fetchBlock({
+      onSuccess: (response) => dispatch(actions.app.setBlockValue(response)),
+      onFailure: (e) => console.log({ fetchFailure: e }),
+    })
+  );
 };
 
 export const fetchStudioView = () => (dispatch) => {
-  dispatch(requests.fetchStudioView({
-    onSuccess: (response) => dispatch(actions.app.setStudioView(response)),
-    onFailure: (e) => dispatch(actions.app.setStudioView(e)),
-  }));
+  dispatch(
+    requests.fetchStudioView({
+      onSuccess: (response) => dispatch(actions.app.setStudioView(response)),
+      onFailure: (e) => dispatch(actions.app.setStudioView(e)),
+    })
+  );
 };
 
 export const fetchUnit = () => (dispatch) => {
-  dispatch(requests.fetchUnit({
-    onSuccess: (response) => dispatch(actions.app.setUnitUrl(response)),
-    onFailure: (e) => dispatch(actions.app.setUnitUrl(e)),
-  }));
+  dispatch(
+    requests.fetchUnit({
+      onSuccess: (response) => dispatch(actions.app.setUnitUrl(response)),
+      onFailure: (e) => dispatch(actions.app.setUnitUrl(e)),
+    })
+  );
 };
 
 /**
@@ -42,13 +48,15 @@ export const initialize = (data) => (dispatch) => {
  */
 export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
   dispatch(actions.app.setBlockContent(content));
-  dispatch(requests.saveBlock({
-    content,
-    onSuccess: (response) => {
-      dispatch(actions.app.setSaveResponse(response));
-      returnToUnit();
-    },
-  }));
+  dispatch(
+    requests.saveBlock({
+      content,
+      onSuccess: (response) => {
+        dispatch(actions.app.setSaveResponse(response));
+        returnToUnit();
+      },
+    })
+  );
 };
 
 export const fetchImages = ({ setImages }) => (dispatch) => {
@@ -56,14 +64,12 @@ export const fetchImages = ({ setImages }) => (dispatch) => {
 };
 
 export const uploadImage = ({ file, setSelection }) => (dispatch) => {
-  console.log(file)
-  if (file.size > 10000000) {
-    console.log('image is too big')
-  }
-  dispatch(requests.uploadImage({
-    image: file,
-    onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),
-  }));
+  dispatch(
+    requests.uploadImage({
+      image: file,
+      onSuccess: (response) => setSelection(camelizeKeys(response.data.asset)),
+    })
+  );
 };
 
 export const fetchVideos = ({ onSuccess }) => (dispatch) => {

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -47,14 +47,13 @@ export const networkRequest = ({
  */
 export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.fetchBlock,
-      promise: api.fetchBlockById({
-        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-        blockId: selectors.app.blockId(getState()),
-      }),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.fetchBlock,
+    promise: api.fetchBlockById({
+      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+      blockId: selectors.app.blockId(getState()),
+    }),
+    ...rest,
+  }));
 };
 
 /**
@@ -65,14 +64,13 @@ export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
  */
 export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.fetchStudioView,
-      promise: api.fetchStudioView({
-        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-        blockId: selectors.app.blockId(getState()),
-      }),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.fetchStudioView,
+    promise: api.fetchStudioView({
+      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+      blockId: selectors.app.blockId(getState()),
+    }),
+    ...rest,
+  }));
 };
 
 /**
@@ -83,14 +81,13 @@ export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
  */
 export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.fetchUnit,
-      promise: api.fetchByUnitId({
-        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-        blockId: selectors.app.blockId(getState()),
-      }),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.fetchUnit,
+    promise: api.fetchByUnitId({
+      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+      blockId: selectors.app.blockId(getState()),
+    }),
+    ...rest,
+  }));
 };
 
 /**
@@ -101,44 +98,41 @@ export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
  */
 export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.saveBlock,
-      promise: api.saveBlock({
-        blockId: selectors.app.blockId(getState()),
-        blockType: selectors.app.blockType(getState()),
-        learningContextId: selectors.app.learningContextId(getState()),
-        content,
-        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-        title: selectors.app.blockTitle(getState()),
-      }),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.saveBlock,
+    promise: api.saveBlock({
+      blockId: selectors.app.blockId(getState()),
+      blockType: selectors.app.blockType(getState()),
+      learningContextId: selectors.app.learningContextId(getState()),
+      content,
+      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+      title: selectors.app.blockTitle(getState()),
+    }),
+    ...rest,
+  }));
 };
 export const uploadImage = ({ image, ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.uploadImage,
-      promise: api.uploadImage({
-        learningContextId: selectors.app.learningContextId(getState()),
-        image,
-        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      }),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.uploadImage,
+    promise: api.uploadImage({
+      learningContextId: selectors.app.learningContextId(getState()),
+      image,
+      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+    }),
+    ...rest,
+  }));
 };
 
 export const fetchImages = ({ ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-      requestKey: RequestKeys.fetchImages,
-      promise: api
-        .fetchImages({
-          studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-          learningContextId: selectors.app.learningContextId(getState()),
-        })
-        .then((response) => loadImages(response.data.assets)),
-      ...rest,
-    })
-  );
+    requestKey: RequestKeys.fetchImages,
+    promise: api
+      .fetchImages({
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+        learningContextId: selectors.app.learningContextId(getState()),
+      })
+      .then((response) => loadImages(response.data.assets)),
+    ...rest,
+  }));
 };
 
 export default StrictDict({

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -1,10 +1,10 @@
-import { StrictDict } from "../../../utils";
+import { StrictDict } from '../../../utils';
 
-import { RequestKeys } from "../../constants/requests";
-import { actions, selectors } from "..";
-import api, { loadImages } from "../../services/cms/api";
+import { RequestKeys } from '../../constants/requests';
+import { actions, selectors } from '..';
+import api, { loadImages } from '../../services/cms/api';
 
-import * as module from "./requests";
+import * as module from './requests';
 
 /**
  * Wrapper around a network request promise, that sends actions to the redux store to
@@ -23,14 +23,12 @@ export const networkRequest = ({
   onSuccess,
   onFailure,
 }) => (dispatch) => {
-  console.log("pending");
   dispatch(actions.requests.startRequest(requestKey));
   return promise
     .then((response) => {
       if (onSuccess) {
         onSuccess(response);
       }
-      console.log("complete");
       dispatch(actions.requests.completeRequest({ requestKey, response }));
     })
     .catch((error) => {
@@ -48,8 +46,7 @@ export const networkRequest = ({
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.fetchBlock,
       promise: api.fetchBlockById({
         studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
@@ -67,8 +64,7 @@ export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.fetchStudioView,
       promise: api.fetchStudioView({
         studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
@@ -86,8 +82,7 @@ export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.fetchUnit,
       promise: api.fetchByUnitId({
         studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
@@ -105,8 +100,7 @@ export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.saveBlock,
       promise: api.saveBlock({
         blockId: selectors.app.blockId(getState()),
@@ -121,9 +115,7 @@ export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
   );
 };
 export const uploadImage = ({ image, ...rest }) => (dispatch, getState) => {
-  console.log("upload image");
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.uploadImage,
       promise: api.uploadImage({
         learningContextId: selectors.app.learningContextId(getState()),
@@ -136,8 +128,7 @@ export const uploadImage = ({ image, ...rest }) => (dispatch, getState) => {
 };
 
 export const fetchImages = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(
-    module.networkRequest({
+  dispatch(module.networkRequest({
       requestKey: RequestKeys.fetchImages,
       promise: api
         .fetchImages({

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -105,6 +105,7 @@ export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
   }));
 };
 export const uploadImage = ({ image, ...rest }) => (dispatch, getState) => {
+  console.log("uploading image", image)
   dispatch(module.networkRequest({
     requestKey: RequestKeys.uploadImage,
     promise: api.uploadImage({

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -1,10 +1,10 @@
-import { StrictDict } from '../../../utils';
+import { StrictDict } from "../../../utils";
 
-import { RequestKeys } from '../../constants/requests';
-import { actions, selectors } from '..';
-import api, { loadImages } from '../../services/cms/api';
+import { RequestKeys } from "../../constants/requests";
+import { actions, selectors } from "..";
+import api, { loadImages } from "../../services/cms/api";
 
-import * as module from './requests';
+import * as module from "./requests";
 
 /**
  * Wrapper around a network request promise, that sends actions to the redux store to
@@ -23,14 +23,22 @@ export const networkRequest = ({
   onSuccess,
   onFailure,
 }) => (dispatch) => {
+  console.log("pending");
   dispatch(actions.requests.startRequest(requestKey));
-  return promise.then((response) => {
-    if (onSuccess) { onSuccess(response); }
-    dispatch(actions.requests.completeRequest({ requestKey, response }));
-  }).catch((error) => {
-    if (onFailure) { onFailure(error); }
-    dispatch(actions.requests.failRequest({ requestKey, error }));
-  });
+  return promise
+    .then((response) => {
+      if (onSuccess) {
+        onSuccess(response);
+      }
+      console.log("complete");
+      dispatch(actions.requests.completeRequest({ requestKey, response }));
+    })
+    .catch((error) => {
+      if (onFailure) {
+        onFailure(error);
+      }
+      dispatch(actions.requests.failRequest({ requestKey, error }));
+    });
 };
 
 /**
@@ -40,14 +48,16 @@ export const networkRequest = ({
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.fetchBlock,
-    promise: api.fetchBlockById({
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      blockId: selectors.app.blockId(getState()),
-    }),
-    ...rest,
-  }));
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.fetchBlock,
+      promise: api.fetchBlockById({
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+        blockId: selectors.app.blockId(getState()),
+      }),
+      ...rest,
+    })
+  );
 };
 
 /**
@@ -57,14 +67,16 @@ export const fetchBlock = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.fetchStudioView,
-    promise: api.fetchStudioView({
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      blockId: selectors.app.blockId(getState()),
-    }),
-    ...rest,
-  }));
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.fetchStudioView,
+      promise: api.fetchStudioView({
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+        blockId: selectors.app.blockId(getState()),
+      }),
+      ...rest,
+    })
+  );
 };
 
 /**
@@ -74,14 +86,16 @@ export const fetchStudioView = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.fetchUnit,
-    promise: api.fetchByUnitId({
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      blockId: selectors.app.blockId(getState()),
-    }),
-    ...rest,
-  }));
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.fetchUnit,
+      promise: api.fetchByUnitId({
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+        blockId: selectors.app.blockId(getState()),
+      }),
+      ...rest,
+    })
+  );
 };
 
 /**
@@ -91,41 +105,49 @@ export const fetchUnit = ({ ...rest }) => (dispatch, getState) => {
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
 export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.saveBlock,
-    promise: api.saveBlock({
-      blockId: selectors.app.blockId(getState()),
-      blockType: selectors.app.blockType(getState()),
-      learningContextId: selectors.app.learningContextId(getState()),
-      content,
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      title: selectors.app.blockTitle(getState()),
-    }),
-    ...rest,
-  }));
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.saveBlock,
+      promise: api.saveBlock({
+        blockId: selectors.app.blockId(getState()),
+        blockType: selectors.app.blockType(getState()),
+        learningContextId: selectors.app.learningContextId(getState()),
+        content,
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+        title: selectors.app.blockTitle(getState()),
+      }),
+      ...rest,
+    })
+  );
 };
 export const uploadImage = ({ image, ...rest }) => (dispatch, getState) => {
-  console.log("uploading image", image)
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.uploadImage,
-    promise: api.uploadImage({
-      learningContextId: selectors.app.learningContextId(getState()),
-      image,
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-    }),
-    ...rest,
-  }));
+  console.log("upload image");
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.uploadImage,
+      promise: api.uploadImage({
+        learningContextId: selectors.app.learningContextId(getState()),
+        image,
+        studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+      }),
+      ...rest,
+    })
+  );
 };
 
 export const fetchImages = ({ ...rest }) => (dispatch, getState) => {
-  dispatch(module.networkRequest({
-    requestKey: RequestKeys.fetchImages,
-    promise: api.fetchImages({
-      studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      learningContextId: selectors.app.learningContextId(getState()),
-    }).then((response) => loadImages(response.data.assets)),
-    ...rest,
-  }));
+  dispatch(
+    module.networkRequest({
+      requestKey: RequestKeys.fetchImages,
+      promise: api
+        .fetchImages({
+          studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
+          learningContextId: selectors.app.learningContextId(getState()),
+        })
+        .then((response) => loadImages(response.data.assets)),
+      ...rest,
+    })
+  );
 };
 
 export default StrictDict({


### PR DESCRIPTION
This PR adds the ability to prevent uploading an image larger than 10 MB and a loading spinner while the image is loading. I changed the error message users see when the upload fails due to file size. The new alert lets users know that the file size it too large instead of a vague error message. New tests added to check the function `checkValidFileSize`'s return value and when it is called. Also made small updates to existing tests.
Jira Ticket: [TNL-9939](https://2u-internal.atlassian.net/browse/TNL-9939)