### PR TITLE
feat: add altText and isDecorative persistence for image editing

### DIFF
--- a/src/editors/containers/TextEditor/components/ImageSettingsModal/DimensionControls.jsx
+++ b/src/editors/containers/TextEditor/components/ImageSettingsModal/DimensionControls.jsx
@@ -70,8 +70,8 @@ export const DimensionControls = ({
 ));
 DimensionControls.defaultProps = {
   value: {
-    height: 100,
-    width: 100,
+    height: '100',
+    width: '100',
   },
 };
 DimensionControls.propTypes = ({

--- a/src/editors/containers/TextEditor/components/ImageSettingsModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/ImageSettingsModal/hooks.js
@@ -136,14 +136,14 @@ export const dimensionHooks = (altTextHook) => {
   const [dimensions, setDimensions] = module.state.dimensions(null);
   const [local, setLocal] = module.state.local(null);
   const setAll = ({ height, width, altText }) => {
-    if (altText == '' || altText) {
-      if (altText == '') {
+    if (altText === '' || altText) {
+      if (altText === '') {
         altTextHook.setIsDecorative(true);
       }
       altTextHook.setValue(altText);
     }
     setDimensions({ height, width });
-    setLocal({ height, width,  });
+    setLocal({ height, width });
   };
   const {
     initializeLock,

--- a/src/editors/containers/TextEditor/components/ImageSettingsModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/ImageSettingsModal/hooks.js
@@ -132,13 +132,18 @@ export const dimensionLockHooks = () => {
  *     {func} setWidthValid - sets isWidthValid to true
  *     {func} setWidthNotValid - sets isWidthValid to false
  */
-export const dimensionHooks = () => {
+export const dimensionHooks = (altTextHook) => {
   const [dimensions, setDimensions] = module.state.dimensions(null);
   const [local, setLocal] = module.state.local(null);
-
-  const setAll = ({ height, width }) => {
+  const setAll = ({ height, width, altText }) => {
+    if (altText == '' || altText) {
+      if (altText == '') {
+        altTextHook.setIsDecorative(true);
+      }
+      altTextHook.setValue(altText);
+    }
     setDimensions({ height, width });
-    setLocal({ height, width });
+    setLocal({ height, width,  });
   };
   const {
     initializeLock,

--- a/src/editors/containers/TextEditor/components/ImageSettingsModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/ImageSettingsModal/index.jsx
@@ -32,8 +32,8 @@ export const ImageSettingsModal = ({
   // inject
   intl,
 }) => {
-  const dimensions = hooks.dimensions();
-  const altText = hooks.altText();
+  const altText = hooks.altText(selection.altText);
+  const dimensions = hooks.dimensions(altText);
   const onSaveClick = hooks.onSaveClick({
     altText,
     dimensions: dimensions.value,
@@ -94,7 +94,7 @@ ImageSettingsModal.propTypes = {
   selection: PropTypes.shape({
     url: PropTypes.string,
     externalUrl: PropTypes.string,
-    altText: PropTypes.bool,
+    altText: PropTypes.string,
   }).isRequired,
   saveToEditor: PropTypes.func.isRequired,
   returnToSelection: PropTypes.func.isRequired,


### PR DESCRIPTION
This PR fixes the persistence issues with altText and decorative details when editing an image. To fix the persistence, a call to update the values when loading the image was missing. Previously there was only a call to update the image dimension fields. 
Jira Ticket: [TNL-9953](https://2u-internal.atlassian.net/browse/TNL-9953)