### PR TITLE
feat: resolve console errors regarding skin.css

### DIFF
--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -76,6 +76,8 @@ export const editorConfig = ({
   initialValue: blockValue ? blockValue.data.data : '',
   init: {
     ...pluginConfig.config,
+    skin: false,
+    content_css: false,
     content_style: tinyMCEStyles,
     contextmenu: 'link table',
     imagetools_cors_hosts: [removeProtocolFromUrl(lmsEndpointUrl), removeProtocolFromUrl(studioEndpointUrl)],


### PR DESCRIPTION
This PR address the console errors for `skin.css`. The changes add missing boolean attributes in the components init function. No new test required.

JIRA Ticket: [TNL-9974](https://2u-internal.atlassian.net/browse/TNL-9974)