### PR TITLE
feat: change static url to asset url in editor

### DIFF
--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -61,15 +61,30 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <div
-      className="text-center p-6"
-    >
-      <Spinner
-        animation="border"
-        className="m-3"
-        screenreadertext="loading"
-      />
-    </div>
+    <Editor
+      editorConfig={
+        Object {
+          "blockValue": Object {
+            "data": Object {
+              "some": "eDiTablE Text",
+            },
+          },
+          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
+          "images": Object {
+            "sOmEuiMAge": Object {
+              "staTICUrl": "/assets/sOmEuiMAge",
+            },
+          },
+          "initializeEditor": [MockFunction args.intializeEditor],
+          "lmsEndpointUrl": "sOmEvaLue.cOm",
+          "openImgModal": [MockFunction modal.openModal],
+          "openSourceCodeModal": [MockFunction modal.openModal],
+          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
+          "setSelection": [MockFunction hooks.selectedImage.setSelection],
+          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
+        }
+      }
+    />
   </div>
 </EditorContainer>
 `;
@@ -135,15 +150,15 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <div
-      className="text-center p-6"
-    >
-      <Spinner
-        animation="border"
-        className="m-3"
-        screenreadertext="loading"
-      />
-    </div>
+    <RawEditor
+      editorRef={
+        Object {
+          "current": Object {
+            "value": "something",
+          },
+        }
+      }
+    />
   </div>
 </EditorContainer>
 `;
@@ -283,15 +298,30 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <div
-      className="text-center p-6"
-    >
-      <Spinner
-        animation="border"
-        className="m-3"
-        screenreadertext="loading"
-      />
-    </div>
+    <Editor
+      editorConfig={
+        Object {
+          "blockValue": Object {
+            "data": Object {
+              "some": "eDiTablE Text",
+            },
+          },
+          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
+          "images": Object {
+            "sOmEuiMAge": Object {
+              "staTICUrl": "/assets/sOmEuiMAge",
+            },
+          },
+          "initializeEditor": [MockFunction args.intializeEditor],
+          "lmsEndpointUrl": "sOmEvaLue.cOm",
+          "openImgModal": [MockFunction modal.openModal],
+          "openSourceCodeModal": [MockFunction modal.openModal],
+          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
+          "setSelection": [MockFunction hooks.selectedImage.setSelection],
+          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
+        }
+      }
+    />
   </div>
 </EditorContainer>
 `;

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -61,25 +61,15 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <Editor
-      editorConfig={
-        Object {
-          "blockValue": Object {
-            "data": Object {
-              "some": "eDiTablE Text",
-            },
-          },
-          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
-          "initializeEditor": [MockFunction args.intializeEditor],
-          "lmsEndpointUrl": "sOmEvaLue.cOm",
-          "openImgModal": [MockFunction modal.openModal],
-          "openSourceCodeModal": [MockFunction modal.openModal],
-          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
-          "setSelection": [MockFunction hooks.selectedImage.setSelection],
-          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
-        }
-      }
-    />
+    <div
+      className="text-center p-6"
+    >
+      <Spinner
+        animation="border"
+        className="m-3"
+        screenreadertext="loading"
+      />
+    </div>
   </div>
 </EditorContainer>
 `;
@@ -293,25 +283,15 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <Editor
-      editorConfig={
-        Object {
-          "blockValue": Object {
-            "data": Object {
-              "some": "eDiTablE Text",
-            },
-          },
-          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
-          "initializeEditor": [MockFunction args.intializeEditor],
-          "lmsEndpointUrl": "sOmEvaLue.cOm",
-          "openImgModal": [MockFunction modal.openModal],
-          "openSourceCodeModal": [MockFunction modal.openModal],
-          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
-          "setSelection": [MockFunction hooks.selectedImage.setSelection],
-          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
-        }
-      }
-    />
+    <div
+      className="text-center p-6"
+    >
+      <Spinner
+        animation="border"
+        className="m-3"
+        screenreadertext="loading"
+      />
+    </div>
   </div>
 </EditorContainer>
 `;

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -29,6 +29,13 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
           },
         }
       }
+      images={
+        Object {
+          "sOmEuiMAge": Object {
+            "staTICUrl": "/assets/sOmEuiMAge",
+          },
+        }
+      }
       isOpen={false}
       selection="hooks.selectedImage.selection"
       setSelection={[MockFunction hooks.selectedImage.setSelection]}
@@ -43,24 +50,15 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <Editor
-      editorConfig={
-        Object {
-          "blockValue": Object {
-            "data": Object {
-              "some": "eDiTablE Text",
-            },
-          },
-          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
-          "initializeEditor": [MockFunction args.intializeEditor],
-          "lmsEndpointUrl": "sOmEvaLue.cOm",
-          "openModal": [MockFunction modal.openModal],
-          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
-          "setSelection": [MockFunction hooks.selectedImage.setSelection],
-          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
-        }
-      }
-    />
+    <div
+      className="text-center p-6"
+    >
+      <Spinner
+        animation="border"
+        className="m-3"
+        screenreadertext="loading"
+      />
+    </div>
   </div>
 </EditorContainer>
 `;
@@ -94,6 +92,13 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
           },
         }
       }
+      images={
+        Object {
+          "sOmEuiMAge": Object {
+            "staTICUrl": "/assets/sOmEuiMAge",
+          },
+        }
+      }
       isOpen={false}
       selection="hooks.selectedImage.selection"
       setSelection={[MockFunction hooks.selectedImage.setSelection]}
@@ -108,15 +113,15 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <RawEditor
-      editorRef={
-        Object {
-          "current": Object {
-            "value": "something",
-          },
-        }
-      }
-    />
+    <div
+      className="text-center p-6"
+    >
+      <Spinner
+        animation="border"
+        className="m-3"
+        screenreadertext="loading"
+      />
+    </div>
   </div>
 </EditorContainer>
 `;
@@ -147,6 +152,13 @@ exports[`TextEditor snapshots not yet loaded, Spinner appears 1`] = `
         Object {
           "current": Object {
             "value": "something",
+          },
+        }
+      }
+      images={
+        Object {
+          "sOmEuiMAge": Object {
+            "staTICUrl": "/assets/sOmEuiMAge",
           },
         }
       }
@@ -206,6 +218,13 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
           },
         }
       }
+      images={
+        Object {
+          "sOmEuiMAge": Object {
+            "staTICUrl": "/assets/sOmEuiMAge",
+          },
+        }
+      }
       isOpen={false}
       selection="hooks.selectedImage.selection"
       setSelection={[MockFunction hooks.selectedImage.setSelection]}
@@ -220,24 +239,15 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
         id="authoring.texteditor.load.error"
       />
     </Toast>
-    <Editor
-      editorConfig={
-        Object {
-          "blockValue": Object {
-            "data": Object {
-              "some": "eDiTablE Text",
-            },
-          },
-          "clearSelection": [MockFunction hooks.selectedImage.clearSelection],
-          "initializeEditor": [MockFunction args.intializeEditor],
-          "lmsEndpointUrl": "sOmEvaLue.cOm",
-          "openModal": [MockFunction modal.openModal],
-          "setEditorRef": [MockFunction hooks.prepareEditorRef.setEditorRef],
-          "setSelection": [MockFunction hooks.selectedImage.setSelection],
-          "studioEndpointUrl": "sOmEoThERvaLue.cOm",
-        }
-      }
-    />
+    <div
+      className="text-center p-6"
+    >
+      <Spinner
+        animation="border"
+        className="m-3"
+        screenreadertext="loading"
+      />
+    </div>
   </div>
 </EditorContainer>
 `;

--- a/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
+++ b/src/editors/containers/TextEditor/components/ImageUploadModal.jsx
@@ -52,6 +52,7 @@ export const ImageUploadModal = ({
   clearSelection,
   selection,
   setSelection,
+  images,
 }) => {
   if (selection) {
     return (
@@ -78,6 +79,7 @@ export const ImageUploadModal = ({
         close,
         setSelection,
         clearSelection,
+        images,
       }}
     />
   );
@@ -101,5 +103,6 @@ ImageUploadModal.propTypes = {
     altText: PropTypes.bool,
   }),
   setSelection: PropTypes.func.isRequired,
+  images: PropTypes.shape({}).isRequired,
 };
 export default ImageUploadModal;

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -29,12 +29,11 @@ export const filteredList = ({ searchString, imageList }) => (
   imageList.filter(({ displayName }) => displayName.toLowerCase().includes(searchString.toLowerCase()))
 );
 
-export const displayList = ({ sortBy, searchString, images }) => {
-  return (
+export const displayList = ({ sortBy, searchString, images }) => (
   module.filteredList({
     searchString,
     imageList: Object.values(images),
-  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]))};
+  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]));
 
 export const imgListHooks = ({ searchSortProps, setSelection, images }) => {
   const [highlighted, setHighlighted] = module.state.highlighted(null);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -68,7 +68,6 @@ export const imgListHooks = ({ searchSortProps, setSelection, images }) => {
     selectBtnProps: {
       onClick: () => {
         if (highlighted) {
-          console.log(images[highlighted]);
           setSelection(images[highlighted]);
         } else {
           setShowSelectImageError(true);

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.js
@@ -7,7 +7,6 @@ import { sortFunctions, sortKeys } from './utils';
 
 export const state = {
   highlighted: (val) => React.useState(val),
-  images: (val) => React.useState(val),
   showSelectImageError: (val) => React.useState(val),
   searchString: (val) => React.useState(val),
   sortBy: (val) => React.useState(val),
@@ -30,15 +29,14 @@ export const filteredList = ({ searchString, imageList }) => (
   imageList.filter(({ displayName }) => displayName.toLowerCase().includes(searchString.toLowerCase()))
 );
 
-export const displayList = ({ sortBy, searchString, images }) => (
+export const displayList = ({ sortBy, searchString, images }) => {
+  return (
   module.filteredList({
     searchString,
     imageList: Object.values(images),
-  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]));
+  }).sort(sortFunctions[sortBy in sortKeys ? sortKeys[sortBy] : sortKeys.dateNewest]))};
 
-export const imgListHooks = ({ searchSortProps, setSelection }) => {
-  const dispatch = useDispatch();
-  const [images, setImages] = module.state.images({});
+export const imgListHooks = ({ searchSortProps, setSelection, images }) => {
   const [highlighted, setHighlighted] = module.state.highlighted(null);
   const [
     showSelectImageError,
@@ -46,10 +44,6 @@ export const imgListHooks = ({ searchSortProps, setSelection }) => {
   ] = module.state.showSelectImageError(false);
   const [showSizeError, setShowSizeError] = module.state.showSelectImageError(false);
   const list = module.displayList({ ...searchSortProps, images });
-
-  React.useEffect(() => {
-    dispatch(thunkActions.app.fetchImages({ setImages }));
-  }, []);
 
   return {
     galleryError: {
@@ -74,6 +68,7 @@ export const imgListHooks = ({ searchSortProps, setSelection }) => {
     selectBtnProps: {
       onClick: () => {
         if (highlighted) {
+          console.log(images[highlighted]);
           setSelection(images[highlighted]);
         } else {
           setShowSelectImageError(true);
@@ -126,9 +121,9 @@ export const fileInputHooks = ({ setSelection, clearSelection, imgList }) => {
   };
 };
 
-export const imgHooks = ({ setSelection, clearSelection }) => {
+export const imgHooks = ({ setSelection, clearSelection, images }) => {
   const searchSortProps = module.searchAndSortHooks();
-  const imgList = module.imgListHooks({ setSelection, searchSortProps });
+  const imgList = module.imgListHooks({ setSelection, searchSortProps, images });
   const fileInput = module.fileInputHooks({
     setSelection,
     clearSelection,

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -27,25 +27,6 @@ jest.mock('react-redux', () => {
 jest.mock('../../../../data/redux', () => ({
   thunkActions: {
     app: {
-      fetchImages: jest.fn(),
-      uploadImage: jest.fn(),
-    },
-  },
-}));
-
-jest.mock('react-redux', () => {
-  const dispatchFn = jest.fn();
-  return {
-    ...jest.requireActual('react-redux'),
-    dispatch: dispatchFn,
-    useDispatch: jest.fn(() => dispatchFn),
-  };
-});
-
-jest.mock('../../../../data/redux', () => ({
-  thunkActions: {
-    app: {
-      fetchImages: jest.fn(),
       uploadImage: jest.fn(),
     },
   },
@@ -63,7 +44,6 @@ describe('SelectImageModal hooks', () => {
   });
   describe('state hooks', () => {
     state.testGetter(state.keys.highlighted);
-    state.testGetter(state.keys.images);
     state.testGetter(state.keys.showSelectImageError);
     state.testGetter(state.keys.searchString);
     state.testGetter(state.keys.sortBy);
@@ -156,6 +136,12 @@ describe('SelectImageModal hooks', () => {
       const props = {
         setSelection: jest.fn(),
         searchSortProps: { searchString: 'Es', sortBy: sortKeys.dateNewest },
+        images: {
+          sOmEuiMAgeURl: {
+            displayName: 'sOmEuiMAge',
+            staTICUrl: '/assets/sOmEuiMAge'
+          },
+        },
       };
       const displayList = (args) => ({ displayList: args });
       const load = () => {
@@ -165,31 +151,19 @@ describe('SelectImageModal hooks', () => {
       beforeEach(() => {
         load();
       });
-      it('returns images value, initialized to an empty object', () => {
-        expect(state.stateVals.images).toEqual(hook.images);
-        expect(state.stateVals.images).toEqual({});
-      });
-      it('dispatches fetchImages thunkAction once, with setImages as onSuccess param', () => {
-        expect(React.useEffect.mock.calls.length).toEqual(1);
-        const [cb, prereqs] = React.useEffect.mock.calls[0];
-        expect(prereqs).toEqual([]);
-        cb();
-        expect(dispatch).toHaveBeenCalledWith(
-          thunkActions.app.fetchImages({ setImages: state.setState.images }),
-        );
-      });
       describe('selectBtnProps', () => {
         test('on click, if sets selection to the image with the same id', () => {
-          const highlighted = 'id1';
-          state.mockVal(state.keys.images, { [highlighted]: testValue });
+          const highlighted = 'sOmEuiMAgeURl';
+          const highlightedValue = { displayName: 'sOmEuiMAge', staTICUrl: '/assets/sOmEuiMAge' };
+          // state.mockVal(props.images, { [highlighted]: testValue });
+          // props.images = {...props.images, [highlighted]: testValue};
           state.mockVal(state.keys.highlighted, highlighted);
           load();
           expect(props.setSelection).not.toHaveBeenCalled();
           hook.selectBtnProps.onClick();
-          expect(props.setSelection).toHaveBeenCalledWith(testValue);
+          expect(props.setSelection).toHaveBeenCalledWith(highlightedValue);
         });
         test('on click, sets showSelectImageError to true if nothing is highlighted', () => {
-          state.mockVal(state.keys.images, { });
           state.mockVal(state.keys.highlighted, null);
           load();
           hook.selectBtnProps.onClick();
@@ -209,7 +183,7 @@ describe('SelectImageModal hooks', () => {
         test('displayList returns displayListhook called with searchSortProps and images', () => {
           expect(hook.galleryProps.displayList).toEqual(displayList({
             ...props.searchSortProps,
-            images: hook.images,
+            images: props.images,
           }));
         });
       });
@@ -307,6 +281,7 @@ describe('SelectImageModal hooks', () => {
     };
     const searchAndSortHooks = { search: 'props' };
     const fileInputHooks = { file: 'input hooks' };
+    const images = { sOmEuiMAge: { staTICUrl: '/assets/sOmEuiMAge' } };
 
     const setSelection = jest.fn();
     const clearSelection = jest.fn();
@@ -318,7 +293,7 @@ describe('SelectImageModal hooks', () => {
         .mockReturnValueOnce(searchAndSortHooks);
       spies.file = jest.spyOn(hooks, hookKeys.fileInputHooks)
         .mockReturnValueOnce(fileInputHooks);
-      hook = hooks.imgHooks({ setSelection, clearSelection });
+      hook = hooks.imgHooks({ setSelection, clearSelection, images });
     });
     it('forwards fileInputHooks as fileInput, called with uploadImage prop', () => {
       expect(hook.fileInput).toEqual(fileInputHooks);
@@ -327,11 +302,12 @@ describe('SelectImageModal hooks', () => {
         setSelection, clearSelection, imgList: imgListHooks,
       });
     });
-    it('initializes imgListHooks with setSelection and searchAndSortHooks', () => {
+    it('initializes imgListHooks with setSelection,searchAndSortHooks, and images', () => {
       expect(spies.imgList.mock.calls.length).toEqual(1);
       expect(spies.imgList).toHaveBeenCalledWith({
         setSelection,
         searchSortProps: searchAndSortHooks,
+        images,
       });
     });
     it('forwards searchAndSortHooks as searchSortProps', () => {

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -155,8 +155,6 @@ describe('SelectImageModal hooks', () => {
         test('on click, if sets selection to the image with the same id', () => {
           const highlighted = 'sOmEuiMAgeURl';
           const highlightedValue = { displayName: 'sOmEuiMAge', staTICUrl: '/assets/sOmEuiMAge' };
-          // state.mockVal(props.images, { [highlighted]: testValue });
-          // props.images = {...props.images, [highlighted]: testValue};
           state.mockVal(state.keys.highlighted, highlighted);
           load();
           expect(props.setSelection).not.toHaveBeenCalled();

--- a/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/hooks.test.js
@@ -139,7 +139,7 @@ describe('SelectImageModal hooks', () => {
         images: {
           sOmEuiMAgeURl: {
             displayName: 'sOmEuiMAge',
-            staTICUrl: '/assets/sOmEuiMAge'
+            staTICUrl: '/assets/sOmEuiMAge',
           },
         },
       };

--- a/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/index.jsx
@@ -27,6 +27,7 @@ export const SelectImageModal = ({
   close,
   setSelection,
   clearSelection,
+  images,
   // injected
   intl,
   // redux
@@ -39,7 +40,7 @@ export const SelectImageModal = ({
     galleryProps,
     searchSortProps,
     selectBtnProps,
-  } = hooks.imgHooks({ setSelection, clearSelection });
+  } = hooks.imgHooks({ setSelection, clearSelection, images });
 
   return (
     <BaseModal
@@ -96,6 +97,7 @@ SelectImageModal.propTypes = {
   close: PropTypes.func.isRequired,
   setSelection: PropTypes.func.isRequired,
   clearSelection: PropTypes.func.isRequired,
+  images: PropTypes.shape({}).isRequired,
   // injected
   intl: intlShape.isRequired,
   // redux

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -1,9 +1,7 @@
 import {
   useRef, useEffect, useCallback, useState,
 } from 'react';
-import { useDispatch } from 'react-redux';
 
-import { thunkActions } from '../../data/redux';
 import { StrictDict } from '../../utils';
 import tinyMCE from '../../data/constants/tinyMCE';
 import tinyMCEStyles from '../../data/constants/tinyMCEStyles';
@@ -153,15 +151,6 @@ export const getContent = ({ editorRef, isRaw }) => () => {
     return editorRef.current.value;
   }
   return editorRef.current?.getContent();
-};
-
-export const fetchImageAssets = (blockFinished) => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    if (blockFinished) {
-      dispatch(thunkActions.app.fetchImages());
-    }
-  }, []);
 };
 
 export const fetchImageUrls = (images) => {

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -60,25 +60,30 @@ export const setupCustomBehavior = ({
   });
 };
 
+export const replaceStaticwithAsset = (editor, imageUrls) => {
+  const content = editor.getContent()
+  const imageSrcs = content.split('img src="');
+  imageSrcs.forEach(src => {
+    if (src.startsWith('/static/') && imageUrls.length > 0) {
+      const imgName = src.substring(8, src.indexOf('"'));
+      let staticFullUrl;
+      imageUrls.forEach((url) => {
+        if (url.includes(imgName)) {
+          staticFullUrl = url;
+        }
+      });
+      const currentSrc = src.substring(0, src.indexOf('"'));
+      const updatedContent = content.replace(currentSrc, staticFullUrl);
+      editor.setContent(updatedContent);
+    }
+  });
+
+}
+
 export const checkRelativeUrl = (imageUrls) => (editor) => {
   editor.on('ExecCommand', (e) => {
     if (e.command === 'mceFocus') {
-      const content = editor.getContent();
-      const imageSrcs = content.split('img src="');
-      imageSrcs.forEach(src => {
-        if (src.startsWith('/static/') && imageUrls.length > 0) {
-          const imgName = src.substring(8, src.indexOf('"'));
-          let staticFullUrl;
-          imageUrls.forEach((url) => {
-            if (url.includes(imgName)) {
-              staticFullUrl = url;
-            }
-          });
-          const currentSrc = src.substring(0, src.indexOf('"'));
-          const updatedContent = content.replace(currentSrc, staticFullUrl);
-          editor.setContent(updatedContent);
-        }
-      });
+      module.replaceStaticwithAsset(editor, imageUrls)
     }
   });
 };

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -140,7 +140,7 @@ export const sourceCodeModalToggle = (editorRef) => {
     openSourceCodeModal: () => setIsOpen(true),
     closeSourceCodeModal: () => {
       setIsOpen(false);
-      editorRef.current.focus()
+      editorRef.current.focus();
     },
   };
 };

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -61,7 +61,7 @@ export const setupCustomBehavior = ({
 };
 
 export const replaceStaticwithAsset = (editor, imageUrls) => {
-  const content = editor.getContent()
+  const content = editor.getContent();
   const imageSrcs = content.split('img src="');
   imageSrcs.forEach(src => {
     if (src.startsWith('/static/') && imageUrls.length > 0) {
@@ -77,13 +77,12 @@ export const replaceStaticwithAsset = (editor, imageUrls) => {
       editor.setContent(updatedContent);
     }
   });
-
-}
+};
 
 export const checkRelativeUrl = (imageUrls) => (editor) => {
   editor.on('ExecCommand', (e) => {
     if (e.command === 'mceFocus') {
-      module.replaceStaticwithAsset(editor, imageUrls)
+      module.replaceStaticwithAsset(editor, imageUrls);
     }
   });
 };

--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -133,12 +133,15 @@ export const imgModalToggle = () => {
   };
 };
 
-export const sourceCodeModalToggle = () => {
+export const sourceCodeModalToggle = (editorRef) => {
   const [isSourceCodeOpen, setIsOpen] = module.state.isSourceCodeModalOpen(false);
   return {
     isSourceCodeOpen,
     openSourceCodeModal: () => setIsOpen(true),
-    closeSourceCodeModal: () => setIsOpen(false),
+    closeSourceCodeModal: () => {
+      setIsOpen(false);
+      editorRef.current.focus()
+    },
   };
 };
 

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -90,12 +90,12 @@ describe('TextEditor hooks', () => {
       const editor = { getContent: jest.fn(() => '<img src="/static/soMEImagEURl1.jpeg"/>'), setContent: jest.fn() };
       const imageUrls = ['soMEImagEURl1.jpeg'];
       module.replaceStaticwithAsset(editor, imageUrls);
-      expect(editor.getContent).toHaveBeenCalled()
-      expect(editor.setContent).toHaveBeenCalled()
-    })
+      expect(editor.getContent).toHaveBeenCalled();
+      expect(editor.setContent).toHaveBeenCalled();
+    });
 
     describe('checkRelativeUrl', () => {
-      const editor = { on: jest.fn() }
+      const editor = { on: jest.fn() };
       const imageUrls = ['soMEImagEURl1'];
       module.checkRelativeUrl(imageUrls)(editor);
       expect(editor.on).toHaveBeenCalled();

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -90,6 +90,7 @@ describe('TextEditor hooks', () => {
         blockValue: null,
         lmsEndpointUrl: 'sOmEuRl.cOm',
         studioEndpointUrl: 'sOmEoThEruRl.cOm',
+        images: { sOmEuiMAge: { staTICUrl: '/assets/sOmEuiMAge' } },
       };
       const evt = 'fakeEvent';
       const editor = 'myEditor';

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -86,6 +86,21 @@ describe('TextEditor hooks', () => {
       });
     });
 
+    describe('replaceStaticwithAsset', () => {
+      const editor = { getContent: jest.fn(() => '<img src="/static/soMEImagEURl1.jpeg"/>'), setContent: jest.fn() };
+      const imageUrls = ['soMEImagEURl1.jpeg'];
+      module.replaceStaticwithAsset(editor, imageUrls);
+      expect(editor.getContent).toHaveBeenCalled()
+      expect(editor.setContent).toHaveBeenCalled()
+    })
+
+    describe('checkRelativeUrl', () => {
+      const editor = { on: jest.fn() }
+      const imageUrls = ['soMEImagEURl1'];
+      module.checkRelativeUrl(imageUrls)(editor);
+      expect(editor.on).toHaveBeenCalled();
+    });
+
     describe('editorConfig', () => {
       const props = {
         blockValue: null,
@@ -139,6 +154,11 @@ describe('TextEditor hooks', () => {
           }),
         );
       });
+      // it('calls checkRelativeUrl on callback', () => {
+      //   expect(output.init.init_instance_callback).toEqual(
+      //     checkRelativeUrl(fetchImageUrls(props.images))
+      //   )
+      // });
     });
 
     describe('imgModalToggle', () => {

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -154,11 +154,6 @@ describe('TextEditor hooks', () => {
           }),
         );
       });
-      // it('calls checkRelativeUrl on callback', () => {
-      //   expect(output.init.init_instance_callback).toEqual(
-      //     checkRelativeUrl(fetchImageUrls(props.images))
-      //   )
-      // });
     });
 
     describe('imgModalToggle', () => {

--- a/src/editors/containers/TextEditor/hooks.test.jsx
+++ b/src/editors/containers/TextEditor/hooks.test.jsx
@@ -160,9 +160,10 @@ describe('TextEditor hooks', () => {
     });
 
     describe('sourceCodeModalToggle', () => {
+      const editorRef = { current: { focus: jest.fn() } };
       const hookKey = state.keys.isSourceCodeModalOpen;
       beforeEach(() => {
-        hook = module.sourceCodeModalToggle();
+        hook = module.sourceCodeModalToggle(editorRef);
       });
       test('isOpen: state value', () => {
         expect(hook.isSourceCodeOpen).toEqual(state.stateVals[hookKey]);

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -43,7 +43,6 @@ export const TextEditor = ({
   lmsEndpointUrl,
   studioEndpointUrl,
   blockFailed,
-  blockFinished,
   initializeEditor,
   images,
   imagesFinished,
@@ -53,7 +52,6 @@ export const TextEditor = ({
   const { editorRef, refReady, setEditorRef } = hooks.prepareEditorRef();
   const { isOpen, openModal, closeModal } = hooks.modalToggle();
   const imageSelection = hooks.selectedImage(null);
-  hooks.fetchImageAssets(blockFinished);
 
   if (!refReady) { return null; }
 
@@ -133,7 +131,6 @@ TextEditor.propTypes = {
   lmsEndpointUrl: PropTypes.string,
   studioEndpointUrl: PropTypes.string,
   blockFailed: PropTypes.bool.isRequired,
-  blockFinished: PropTypes.bool.isRequired,
   initializeEditor: PropTypes.func.isRequired,
   isRaw: PropTypes.bool,
   imagesFinished: PropTypes.bool,
@@ -147,7 +144,6 @@ export const mapStateToProps = (state) => ({
   lmsEndpointUrl: selectors.app.lmsEndpointUrl(state),
   studioEndpointUrl: selectors.app.studioEndpointUrl(state),
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
-  blockFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   isRaw: selectors.app.isRaw(state),
   imagesFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchImages }),
   images: selectors.app.images(state),

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -45,12 +45,15 @@ export const TextEditor = ({
   blockFailed,
   blockFinished,
   initializeEditor,
+  images,
+  imagesFinished,
   // inject
   intl,
 }) => {
   const { editorRef, refReady, setEditorRef } = hooks.prepareEditorRef();
   const { isOpen, openModal, closeModal } = hooks.modalToggle();
   const imageSelection = hooks.selectedImage(null);
+  hooks.fetchImageAssets(blockFinished);
 
   if (!refReady) { return null; }
 
@@ -72,6 +75,7 @@ export const TextEditor = ({
           initializeEditor,
           lmsEndpointUrl,
           studioEndpointUrl,
+          images,
           setSelection: imageSelection.setSelection,
           clearSelection: imageSelection.clearSelection,
         })}
@@ -89,6 +93,7 @@ export const TextEditor = ({
           isOpen={isOpen}
           close={closeModal}
           editorRef={editorRef}
+          images={images}
           {...imageSelection}
         />
 
@@ -96,7 +101,7 @@ export const TextEditor = ({
           <FormattedMessage {...messages.couldNotLoadTextContext} />
         </Toast>
 
-        {(!blockFinished)
+        {(!imagesFinished)
           ? (
             <div className="text-center p-6">
               <Spinner
@@ -116,6 +121,8 @@ TextEditor.defaultProps = {
   isRaw: null,
   lmsEndpointUrl: null,
   studioEndpointUrl: null,
+  images: null,
+  imagesFinished: null,
 };
 TextEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
@@ -129,6 +136,8 @@ TextEditor.propTypes = {
   blockFinished: PropTypes.bool.isRequired,
   initializeEditor: PropTypes.func.isRequired,
   isRaw: PropTypes.bool,
+  imagesFinished: PropTypes.bool,
+  images: PropTypes.shape({}),
   // inject
   intl: intlShape.isRequired,
 };
@@ -140,6 +149,8 @@ export const mapStateToProps = (state) => ({
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
   blockFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   isRaw: selectors.app.isRaw(state),
+  imagesFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchImages }),
+  images: selectors.app.images(state),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -52,7 +52,7 @@ export const TextEditor = ({
 }) => {
   const { editorRef, refReady, setEditorRef } = hooks.prepareEditorRef();
   const { isImgOpen, openImgModal, closeImgModal } = hooks.imgModalToggle();
-  const { isSourceCodeOpen, openSourceCodeModal, closeSourceCodeModal } = hooks.sourceCodeModalToggle();
+  const { isSourceCodeOpen, openSourceCodeModal, closeSourceCodeModal } = hooks.sourceCodeModalToggle(editorRef);
   const imageSelection = hooks.selectedImage(null);
 
   if (!refReady) { return null; }

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -87,9 +87,9 @@ describe('TextEditor', () => {
     lmsEndpointUrl: 'sOmEvaLue.cOm',
     studioEndpointUrl: 'sOmEoThERvaLue.cOm',
     blockFailed: false,
-    blockFinished: true,
     initializeEditor: jest.fn().mockName('args.intializeEditor'),
     isRaw: false,
+    imagesFinished: true,
     images: { sOmEuiMAge: { staTICUrl: '/assets/sOmEuiMAge' } },
     // inject
     intl: { formatMessage },

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -63,6 +63,7 @@ jest.mock('../../data/redux', () => ({
       lmsEndpointUrl: jest.fn(state => ({ lmsEndpointUrl: state })),
       studioEndpointUrl: jest.fn(state => ({ studioEndpointUrl: state })),
       isRaw: jest.fn(state => ({ isRaw: state })),
+      images: jest.fn(state => ({ images: state })),
     },
     requests: {
       isFailed: jest.fn((state, params) => ({ isFailed: { state, params } })),
@@ -82,6 +83,7 @@ describe('TextEditor', () => {
     blockFinished: true,
     initializeEditor: jest.fn().mockName('args.intializeEditor'),
     isRaw: false,
+    images: { sOmEuiMAge: { staTICUrl: '/assets/sOmEuiMAge' } },
     // inject
     intl: { formatMessage },
   };
@@ -116,15 +118,20 @@ describe('TextEditor', () => {
         mapStateToProps(testState).lmsEndpointUrl,
       ).toEqual(selectors.app.lmsEndpointUrl(testState));
     });
+    test('images from app.images', () => {
+      expect(
+        mapStateToProps(testState).images,
+      ).toEqual(selectors.app.images(testState));
+    });
     test('blockFailed from requests.isFailed', () => {
       expect(
         mapStateToProps(testState).blockFailed,
       ).toEqual(selectors.requests.isFailed(testState, { requestKey: RequestKeys.fetchBlock }));
     });
-    test('blockFinished from requests.isFinished', () => {
+    test('imagesFinished from requests.isFinished', () => {
       expect(
-        mapStateToProps(testState).blockFinished,
-      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }));
+        mapStateToProps(testState).imagesFinished,
+      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchImages }));
     });
   });
   describe('mapDispatchToProps', () => {

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -109,7 +109,7 @@ describe('TextEditor', () => {
       expect(shallow(<TextEditor {...props} />)).toMatchSnapshot();
     });
     test('not yet loaded, Spinner appears', () => {
-      expect(shallow(<TextEditor {...props} blockFinished={false} />)).toMatchSnapshot();
+      expect(shallow(<TextEditor {...props} imagesFinished={false} />)).toMatchSnapshot();
     });
     test('loaded, raw editor', () => {
       expect(shallow(<TextEditor {...props} isRaw />)).toMatchSnapshot();

--- a/src/editors/containers/TextEditor/pluginConfig.js
+++ b/src/editors/containers/TextEditor/pluginConfig.js
@@ -49,6 +49,7 @@ export default StrictDict({
     menubar: false,
     min_height: 500,
     toolbar_sticky: true,
-    relative_urls: false,
+    relative_urls: true,
+    convert_urls: false,
   },
 });

--- a/src/editors/data/redux/app/reducer.js
+++ b/src/editors/data/redux/app/reducer.js
@@ -45,6 +45,7 @@ const app = createSlice({
     setBlockTitle: (state, { payload }) => ({ ...state, blockTitle: payload }),
     setSaveResponse: (state, { payload }) => ({ ...state, saveResponse: payload }),
     initializeEditor: (state) => ({ ...state, editorInitialized: true }),
+    setImages: (state, { payload }) => ({ ...state, images: payload }),
   },
 });
 

--- a/src/editors/data/redux/app/reducer.js
+++ b/src/editors/data/redux/app/reducer.js
@@ -8,7 +8,6 @@ const initialState = {
   blockContent: null,
   studioView: null,
   saveResponse: null,
-
   blockId: null,
   blockTitle: null,
   blockType: null,
@@ -16,6 +15,7 @@ const initialState = {
   editorInitialized: false,
   studioEndpointUrl: null,
   lmsEndpointUrl: null,
+  images: {},
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/src/editors/data/redux/app/reducer.test.js
+++ b/src/editors/data/redux/app/reducer.test.js
@@ -47,6 +47,7 @@ describe('app reducer', () => {
       ['setBlockContent', 'blockContent'],
       ['setBlockTitle', 'blockTitle'],
       ['setSaveResponse', 'saveResponse'],
+      ['setImages', 'images'],
     ].map(args => setterTest(...args));
     describe('setBlockValue', () => {
       it('sets blockValue, as well as setting the blockTitle from data.display_name', () => {

--- a/src/editors/data/redux/app/selectors.js
+++ b/src/editors/data/redux/app/selectors.js
@@ -22,6 +22,7 @@ export const simpleSelectors = {
   studioEndpointUrl: mkSimpleSelector(app => app.studioEndpointUrl),
   unitUrl: mkSimpleSelector(app => app.unitUrl),
   blockTitle: mkSimpleSelector(app => app.blockTitle),
+  images: mkSimpleSelector(app => app.images),
 };
 
 export const returnUrl = createSelector(

--- a/src/editors/data/redux/app/selectors.test.js
+++ b/src/editors/data/redux/app/selectors.test.js
@@ -46,6 +46,7 @@ describe('app selectors unit tests', () => {
         simpleKeys.unitUrl,
         simpleKeys.blockTitle,
         simpleKeys.studioView,
+        simpleKeys.images,
       ].map(testSimpleSelector);
     });
   });

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -51,8 +51,10 @@ export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
   }));
 };
 
-export const fetchImages = ({ setImages }) => (dispatch) => {
-  dispatch(requests.fetchImages({ onSuccess: setImages }));
+export const fetchImages = () => (dispatch) => {
+  dispatch(requests.fetchImages({
+    onSuccess: (response) => dispatch(actions.app.setImages(response)),
+  }));
 };
 
 export const uploadImage = ({ file, setSelection }) => (dispatch) => {

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -24,6 +24,12 @@ export const fetchUnit = () => (dispatch) => {
   }));
 };
 
+export const fetchImages = () => (dispatch) => {
+  dispatch(requests.fetchImages({
+    onSuccess: (response) => dispatch(actions.app.setImages(response)),
+  }));
+};
+
 /**
  * @param {string} studioEndpointUrl
  * @param {string} blockId
@@ -35,6 +41,7 @@ export const initialize = (data) => (dispatch) => {
   dispatch(module.fetchBlock());
   dispatch(module.fetchUnit());
   dispatch(module.fetchStudioView());
+  dispatch(module.fetchImages());
 };
 
 /**
@@ -48,12 +55,6 @@ export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
       dispatch(actions.app.setSaveResponse(response));
       returnToUnit();
     },
-  }));
-};
-
-export const fetchImages = () => (dispatch) => {
-  dispatch(requests.fetchImages({
-    onSuccess: (response) => dispatch(actions.app.setImages(response)),
   }));
 };
 

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -80,20 +80,28 @@ describe('app thunkActions', () => {
   });
   describe('initialize', () => {
     it('dispatches actions.app.initialize, and then fetches both block and unit', () => {
-      const { fetchBlock, fetchUnit, fetchStudioView } = thunkActions;
+      const {
+        fetchBlock,
+        fetchUnit,
+        fetchStudioView,
+        fetchImages,
+      } = thunkActions;
       thunkActions.fetchBlock = () => 'fetchBlock';
       thunkActions.fetchUnit = () => 'fetchUnit';
       thunkActions.fetchStudioView = () => 'fetchStudioView';
+      thunkActions.fetchImages = () => 'fetchImages';
       thunkActions.initialize(testValue)(dispatch);
       expect(dispatch.mock.calls).toEqual([
         [actions.app.initialize(testValue)],
         [thunkActions.fetchBlock()],
         [thunkActions.fetchUnit()],
         [thunkActions.fetchStudioView()],
+        [thunkActions.fetchImages()],
       ]);
       thunkActions.fetchBlock = fetchBlock;
       thunkActions.fetchUnit = fetchUnit;
       thunkActions.fetchStudioView = fetchStudioView;
+      thunkActions.fetchImages = fetchImages;
     });
   });
   describe('saveBlock', () => {
@@ -122,10 +130,11 @@ describe('app thunkActions', () => {
   });
   describe('fetchImages', () => {
     it('dispatches fetchUnit action with setImages for onSuccess param', () => {
-      const setImages = jest.fn();
-      thunkActions.fetchImages({ setImages })(dispatch);
-      [[dispatchedAction]] = dispatch.mock.calls;
-      expect(dispatchedAction.fetchImages).toEqual({ onSuccess: setImages });
+      const response = 'testRESPONSE';
+      thunkActions.fetchImages()(dispatch);
+      const [[dispatchCall]] = dispatch.mock.calls;
+      dispatchCall.fetchImages.onSuccess(response);
+      expect(dispatch).toHaveBeenCalledWith(actions.app.setImages(response));
     });
   });
   describe('uploadImage', () => {


### PR DESCRIPTION
This PR changes `/static/` links to `/assets/` links. This fixes the broken links in the editor view. The links are automatically replaced when the source code is saved and the user is navigated back to the main body of the editor. Updated tests to reflect the new way that `fetchImages` is called and how images are passed between components.

Linked PR:  edx-platform [PR #30886](https://github.com/openedx/edx-platform/pull/30886)

Jira Ticket: [TNL-10077](https://2u-internal.atlassian.net/browse/TNL-10077)