### PR TITLE
feat: add codeMirror lineWrapping extension

### DIFF
--- a/src/editors/containers/TextEditor/components/CodeEditor/index.jsx
+++ b/src/editors/containers/TextEditor/components/CodeEditor/index.jsx
@@ -14,11 +14,12 @@ export const hooks = {
     useEffect(() => {
       const state = EditorState.create({
         doc: initialText,
-        extensions: [basicSetup, html()],
+        extensions: [basicSetup, html(), EditorView.lineWrapping],
       });
       const view = new EditorView({ state, parent: ref.current });
       // eslint-disable-next-line no-param-reassign
       upstreamRef.current = view;
+      view.focus();
       return () => {
         // called on cleanup
         view.destroy();


### PR DESCRIPTION
This PR address the horizontal scroll when editing raw html. Previously the user would manually have to enter for new lines or the line would stretch on forever. This makes it difficult to read the html. Now the text will automatically wrap the line when it hits the edge of the container.

JIRA Ticket: [TNL-10099](https://2u-internal.atlassian.net/browse/TNL-10099)