### PR TITLE
feat: allow .ico image file types

### DIFF
--- a/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/FileInput.test.jsx.snap
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/__snapshots__/FileInput.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`FileInput component snapshot 1`] = `
   }
 >
   <input
-    accept=".gif,.jpg,.jpeg,.png,.tif,.tiff"
+    accept=".gif,.jpg,.jpeg,.png,.tif,.tiff,.ico"
     className="upload d-none"
     onChange={[MockFunction props.fileInput.addFile]}
     type="file"

--- a/src/editors/containers/TextEditor/components/SelectImageModal/utils.js
+++ b/src/editors/containers/TextEditor/components/SelectImageModal/utils.js
@@ -43,4 +43,5 @@ export const acceptedImgKeys = StrictDict({
   png: '.png',
   tif: '.tif',
   tiff: '.tiff',
+  ico: '.ico',
 });


### PR DESCRIPTION
This PR allows .ico images to be uploaded in the text editor. File input snapshot was updated to include new allowed file type and no new tests were added.

JIRA Ticket: [TNL-9952](https://2u-internal.atlassian.net/browse/TNL-9952)