### PR TITLE
fix: text editor save to use assets array instead of object

### DIFF
--- a/src/editors/containers/TextEditor/hooks.js
+++ b/src/editors/containers/TextEditor/hooks.js
@@ -190,7 +190,8 @@ export const setAssetToStaticUrl = ({ editorValue, assets }) => {
   */
   let content = editorValue;
   const assetUrls = [];
-  assets.forEach(asset => {
+  const assetsList = Object.values(assets);
+  assetsList.forEach(asset => {
     assetUrls.push({ portableUrl: asset.portableUrl, displayName: asset.displayName });
   });
   const assetSrcs = typeof content === 'string' ? content.split(/(src="|href=")/g) : [];


### PR DESCRIPTION
This PR fixes bug in main that breaks saving text editor. While updating the text editor to use all assets, not just images, the variables types were not updated for when getting the static url from all the assets.