### PR TITLE
feat: remove handout widget for content libraries

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/__snapshots__/index.test.jsx.snap
@@ -147,3 +147,5 @@ exports[`HandoutWidget snapshots snapshots: renders as expected with handout 1`]
   </Card>
 </injectIntl(ShimmedIntlComponent)>
 `;
+
+exports[`HandoutWidget snapshots snapshots: renders as expected with isLibrary true 1`] = `""`;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.jsx
@@ -34,6 +34,7 @@ export const HandoutWidget = ({
   // injected
   intl,
   // redux
+  isLibrary,
   handout,
   getHandoutDownloadUrl,
   updateField,
@@ -44,7 +45,7 @@ export const HandoutWidget = ({
   const handoutName = hooks.parseHandoutName({ handout });
   const downloadLink = getHandoutDownloadUrl({ handout });
 
-  return (
+  return (!isLibrary ? (
     <CollapsibleFormWidget
       isError={Object.keys(error).length !== 0}
       title={intl.formatMessage(messages.titleLabel)}
@@ -101,19 +102,21 @@ export const HandoutWidget = ({
         </Stack>
       )}
     </CollapsibleFormWidget>
-  );
+  ) : null);
 };
 
 HandoutWidget.propTypes = {
   // injected
   intl: intlShape.isRequired,
   // redux
+  isLibrary: PropTypes.bool.isRequired,
   handout: PropTypes.shape({}).isRequired,
   updateField: PropTypes.func.isRequired,
   isUploadError: PropTypes.bool.isRequired,
   getHandoutDownloadUrl: PropTypes.func.isRequired,
 };
 export const mapStateToProps = (state) => ({
+  isLibrary: selectors.app.isLibrary(state),
   handout: selectors.video.handout(state),
   getHandoutDownloadUrl: selectors.video.getHandoutDownloadUrl(state),
 });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.test.jsx
@@ -21,6 +21,9 @@ jest.mock('../../../../../../data/redux', () => ({
       getHandoutDownloadUrl: jest.fn(args => ({ getHandoutDownloadUrl: args })).mockName('selectors.video.getHandoutDownloadUrl'),
       handout: jest.fn(state => ({ handout: state })),
     },
+    app: {
+      isLibrary: jest.fn(args => ({ isLibrary: args })),
+    },
   },
 }));
 
@@ -29,6 +32,7 @@ describe('HandoutWidget', () => {
     subtitle: 'SuBTItle',
     title: 'tiTLE',
     intl: { formatMessage },
+    isLibrary: false,
     handout: '',
     getHandoutDownloadUrl: jest.fn().mockName('args.getHandoutDownloadUrl'),
     updateField: jest.fn().mockName('args.updateField'),
@@ -40,6 +44,11 @@ describe('HandoutWidget', () => {
         shallow(<HandoutWidget {...props} />),
       ).toMatchSnapshot();
     });
+    test('snapshots: renders as expected with isLibrary true', () => {
+      expect(
+        shallow(<HandoutWidget {...props} isLibrary />),
+      ).toMatchSnapshot();
+    });
     test('snapshots: renders as expected with handout', () => {
       expect(
         shallow(<HandoutWidget {...props} handout="sOMeUrl " />),
@@ -48,10 +57,10 @@ describe('HandoutWidget', () => {
   });
   describe('mapStateToProps', () => {
     const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
-    test('handout from video.handout', () => {
+    test('isLibrary from app.isLibrary', () => {
       expect(
-        mapStateToProps(testState).handout,
-      ).toEqual(selectors.video.handout(testState));
+        mapStateToProps(testState).isLibrary,
+      ).toEqual(selectors.app.isLibrary(testState));
     });
     test('getHandoutDownloadUrl from video.getHandoutDownloadUrl', () => {
       expect(


### PR DESCRIPTION
Content libraries do not have asset pages, so the ability to upload handouts is not possible. As a result, the handout widget is not displayed if it is a library block.