### PR TITLE
feat: remove thumbnail widget from content libraries

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
@@ -187,3 +187,5 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
   </Stack>
 </injectIntl(ShimmedIntlComponent)>
 `;
+
+exports[`ThumbnailWidget snapshots snapshots: renders as expected with isLibrary true 1`] = `""`;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
@@ -33,6 +33,7 @@ export const ThumbnailWidget = ({
   // injected
   intl,
   // redux
+  isLibrary,
   allowThumbnailUpload,
   thumbnail,
   updateField,
@@ -49,7 +50,7 @@ export const ThumbnailWidget = ({
   });
   const isEdxVideo = videoType === 'edxVideo';
 
-  return (
+  return (!isLibrary ? (
     <CollapsibleFormWidget
       isError={Object.keys(error).length !== 0}
       title={intl.formatMessage(messages.title)}
@@ -103,19 +104,21 @@ export const ThumbnailWidget = ({
         </Stack>
       )}
     </CollapsibleFormWidget>
-  );
+  ) : null);
 };
 
 ThumbnailWidget.propTypes = {
   // injected
   intl: intlShape.isRequired,
   // redux
+  isLibrary: PropTypes.bool.isRequired,
   allowThumbnailUpload: PropTypes.bool.isRequired,
   thumbnail: PropTypes.string.isRequired,
   updateField: PropTypes.func.isRequired,
   videoType: PropTypes.string.isRequired,
 };
 export const mapStateToProps = (state) => ({
+  isLibrary: selectors.app.isLibrary(state),
   allowThumbnailUpload: selectors.video.allowThumbnailUpload(state),
   thumbnail: selectors.video.thumbnail(state),
   videoType: selectors.video.videoType(state),

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.test.jsx
@@ -21,6 +21,9 @@ jest.mock('../../../../../../data/redux', () => ({
       thumbnail: jest.fn(state => ({ thumbnail: state })),
       videoType: jest.fn(state => ({ videoType: state })),
     },
+    app: {
+      isLibrary: jest.fn(state => ({ isLibrary: state })),
+    },
   },
 }));
 
@@ -29,6 +32,7 @@ describe('ThumbnailWidget', () => {
     error: {},
     title: 'tiTLE',
     intl: { formatMessage },
+    isLibrary: false,
     allowThumbnailUpload: false,
     thumbnail: null,
     videoType: '',
@@ -39,6 +43,11 @@ describe('ThumbnailWidget', () => {
     test('snapshots: renders as expected with default props', () => {
       expect(
         shallow(<ThumbnailWidget {...props} />),
+      ).toMatchSnapshot();
+    });
+    test('snapshots: renders as expected with isLibrary true', () => {
+      expect(
+        shallow(<ThumbnailWidget {...props} isLibrary />),
       ).toMatchSnapshot();
     });
     test('snapshots: renders as expected with a thumbnail provided', () => {
@@ -59,6 +68,11 @@ describe('ThumbnailWidget', () => {
   });
   describe('mapStateToProps', () => {
     const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
+    test('isLibrary from app.isLibrary', () => {
+      expect(
+        mapStateToProps(testState).isLibrary,
+      ).toEqual(selectors.app.isLibrary(testState));
+    });
     test('allowThumbnailUpload from video.allowThumbnailUpload', () => {
       expect(
         mapStateToProps(testState).allowThumbnailUpload,


### PR DESCRIPTION
Add conditional that checks if the block is from a content library. Content libraries do not host their own videos. Therefore any edx-hosted video present in a content library originates from another course. When trying to upload a new thumbnail it errors out because it is trying to find the video in the library. To prevent this error, the thumbnail widget is not visible to users in content libraries.