### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+docs/decisions/0001-library-adr.rst        @edx/teaching-and-learning


### PR DESCRIPTION
The repo should have a CODEOWNERS file, but this effort is specifically to help test a need to make an edx-platform file notify T&L when changes are made.  We are doing the testing on this edx repo that we own to minimize the churn and impact on edx-platform.

The scope of this effort includes:
1. Create a CODEOWNERS file in this repo that calls out a single file as owned by a team. 
2. Submit a no-change PR to that file and ensure the team is notified 
3. Submit a no-change PR to another file in the repo and ensure the team is NOT notified 
4. Update the CODEOWNERS file to have T&L team as owners of the whole repo, instead of just one file (long term desired state)