### PR TITLE
fix: length error on undefined fallback videos

### DIFF
--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -92,7 +92,7 @@ export const determineVideoSource = ({
     [videoSource, fallbackVideos] = [html5Sources[0], html5Sources.slice(1)];
     videoType = 'html5source';
   }
-  if (fallbackVideos.length === 0) {
+  if (!fallbackVideos || fallbackVideos.length === 0) {
     fallbackVideos = ['', ''];
   }
   return {


### PR DESCRIPTION
JIRA Ticket: [TNL-10227](https://2u-internal.atlassian.net/browse/TNL-10227)

This PR addresses the error message "an unexpected error occurred. Please click the button below to refresh the page.". When course is created with xml, it does not define `html5Sources` as an empty list. This PR updates the conditional that sets `fallbackVideos` to `['', '']` so that it also check for undefined values.