### PR TITLE
feat: left align widget "add" buttons

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/__snapshots__/index.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`HandoutWidget snapshots snapshots: renders as expected with default pro
       id="authoring.videoeditor.handout.upload.addHandoutMessage"
     />
     <Button
-      className="text-primary-500 font-weight-bold"
+      className="text-primary-500 font-weight-bold justify-content-start pl-0"
       onClick={[Function]}
       size="sm"
       variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/index.jsx
@@ -96,7 +96,7 @@ export const HandoutWidget = ({
         <Stack gap={3}>
           <FormattedMessage {...messages.addHandoutMessage} />
           <Button
-            className="text-primary-500 font-weight-bold"
+            className="text-primary-500 font-weight-bold justify-content-start pl-0"
             size="sm"
             iconBefore={FileUpload}
             onClick={fileInput.click}

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/index.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`LicenseWidget snapshots snapshots: renders as expected with default pro
       className="border-primary-100 border-bottom"
     />
     <Button
-      className="text-primary-500 font-weight-bold"
+      className="text-primary-500 font-weight-bold justify-content-start pl-0"
       onClick={[Function]}
       size="sm"
       variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/index.jsx
@@ -71,7 +71,7 @@ export const LicenseWidget = ({
           <>
             <div className="border-primary-100 border-bottom" />
             <Button
-              className="text-primary-500 font-weight-bold"
+              className="text-primary-500 font-weight-bold justify-content-start pl-0"
               size="sm"
               iconBefore={Add}
               variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoTyp
       }
     />
     <Button
-      className="text-primary-500 font-weight-bold"
+      className="text-primary-500 font-weight-bold justify-content-start pl-0"
       disabled={false}
       onClick={[Function]}
       size="sm"
@@ -242,7 +242,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
       }
     />
     <Button
-      className="text-primary-500 font-weight-bold"
+      className="text-primary-500 font-weight-bold justify-content-start pl-0"
       disabled={true}
       onClick={[Function]}
       size="sm"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
@@ -107,7 +107,7 @@ export const ThumbnailWidget = ({
           </div>
           <FileInput fileInput={fileInput} acceptedFiles={Object.values(acceptedImgKeys).join()} />
           <Button
-            className="text-primary-500 font-weight-bold"
+            className="text-primary-500 font-weight-bold justify-content-start pl-0"
             size="sm"
             iconBefore={FileUpload}
             onClick={fileInput.click}

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
@@ -103,7 +103,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"
@@ -226,7 +226,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"
@@ -345,7 +345,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"
@@ -411,7 +411,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"
@@ -530,7 +530,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"
@@ -649,7 +649,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
       gap={3}
     >
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold justify-content-start pl-0"
         onClick={[Function]}
         size="sm"
         variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
@@ -161,7 +161,7 @@ export const TranscriptWidget = ({
 
         <Stack gap={3} className="border-primary-100 border-top">
           <Button
-            className="text-primary-500 font-weight-bold"
+            className="text-primary-500 font-weight-bold justify-content-start pl-0"
             size="sm"
             iconBefore={Add}
             variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
     </ActionRow>
   </Form.Group>
   <Button
-    className="text-primary-500 font-weight-bold"
+    className="text-primary-500 font-weight-bold pl-0"
     onClick={[Function]}
     size="sm"
     variant="link"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
@@ -113,7 +113,7 @@ export const VideoSourceWidget = ({
         </ActionRow>
       </Form.Group>
       <Button
-        className="text-primary-500 font-weight-bold"
+        className="text-primary-500 font-weight-bold pl-0"
         size="sm"
         iconBefore={Add}
         variant="link"


### PR DESCRIPTION
This solves the first half of https://2u-internal.atlassian.net/browse/TNL-10238 "All add/upload links should be left aligned." However, we still need to address "update the color for the upload handout icon to match the other links" in https://github.com/openedx/paragon/issues/1816