### PR TITLE
feat: add black canvas when current thumbnail is deleted

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
@@ -12,13 +12,13 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where thumbnai
     isError={false}
   >
     <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again."
+      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
       description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
   </ErrorAlert>
   <Alert
-    variant="info"
+    variant="light"
   >
     <FormattedMessage
       defaultMessage="Select a video from your library to enable this feature"
@@ -53,7 +53,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoTyp
     isError={false}
   >
     <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again."
+      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
       description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
@@ -91,7 +91,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoTyp
     isError={false}
   >
     <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again."
+      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
       description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
@@ -99,7 +99,9 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoTyp
   <Stack
     gap={3}
   >
-    <div>
+    <div
+      className="text-center"
+    >
       <FormattedMessage
         defaultMessage="Upload an image for learners to see before playing the video."
         description="Message for adding thumbnail"
@@ -107,11 +109,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoTyp
       />
     </div>
     <div
-      style={
-        Object {
-          "color": "grey",
-        }
-      }
+      className="text-center text-primary-300"
     >
       <FormattedMessage
         defaultMessage="Images must have an aspect ratio of 16:9 (1280x720 px recommended)"
@@ -160,7 +158,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with a thumbna
     isError={false}
   >
     <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again."
+      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
       description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
@@ -192,13 +190,13 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
     isError={false}
   >
     <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again."
+      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
       description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
   </ErrorAlert>
   <Alert
-    variant="info"
+    variant="light"
   >
     <FormattedMessage
       defaultMessage="Select a video from your library to enable this feature"
@@ -209,7 +207,9 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
   <Stack
     gap={3}
   >
-    <div>
+    <div
+      className="text-center"
+    >
       <FormattedMessage
         defaultMessage="Upload an image for learners to see before playing the video."
         description="Message for adding thumbnail"
@@ -217,11 +217,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
       />
     </div>
     <div
-      style={
-        Object {
-          "color": "grey",
-        }
-      }
+      className="text-center text-primary-300"
     >
       <FormattedMessage
         defaultMessage="Images must have an aspect ratio of 16:9 (1280x720 px recommended)"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.js
@@ -140,7 +140,7 @@ export const deleteThumbnail = ({ dispatch }) => () => {
   emptyCanvas.height = constants.MAX_HEIGHT;
   ctx.fillStyle = 'black';
   ctx.fillRect(0, 0, emptyCanvas.width, emptyCanvas.height);
-  const file = createResampledFile({ canvasUrl: emptyCanvas.toDataURL(), filename: 'emptyCanvas.png', mimeType: 'image/png' });
+  const file = createResampledFile({ canvasUrl: emptyCanvas.toDataURL(), filename: 'blankThumbnail.png', mimeType: 'image/png' });
   dispatch(thunkActions.video.uploadThumbnail({ thumbnail: file, emptyCanvas }));
 };
 

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.js
@@ -132,7 +132,20 @@ export const fileSizeError = () => {
   };
 };
 
+export const deleteThumbnail = ({ dispatch }) => () => {
+  dispatch(actions.video.updateField({ thumbnail: null }));
+  const emptyCanvas = document.createElement('canvas');
+  const ctx = emptyCanvas.getContext('2d');
+  emptyCanvas.width = constants.MAX_WIDTH;
+  emptyCanvas.height = constants.MAX_HEIGHT;
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, emptyCanvas.width, emptyCanvas.height);
+  const file = createResampledFile({ canvasUrl: emptyCanvas.toDataURL(), filename: 'emptyCanvas.png', mimeType: 'image/png' });
+  dispatch(thunkActions.video.uploadThumbnail({ thumbnail: file, emptyCanvas }));
+};
+
 export default {
   fileInput,
   fileSizeError,
+  deleteThumbnail,
 };

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.test.jsx
@@ -136,4 +136,11 @@ describe('fileInput', () => {
       );
     });
   });
+  describe('deleteThumbnail', () => {
+    const testFile = new File([selectedFileSuccess], 'sOMEUrl.jpg')
+    hooks.deleteThumbnail({ dispatch })();
+    expect(dispatch).toHaveBeenNthCalledWith(1, actions.video.updateField({ thumbnail: null}));
+    expect(hooks.createResampledFile).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenNthCalledWith(2, thunkActions.video.uploadThumbnail({ thumbnail: testFile, emptyCanvas: true}))
+  });
 });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/hooks.test.jsx
@@ -137,10 +137,13 @@ describe('fileInput', () => {
     });
   });
   describe('deleteThumbnail', () => {
-    const testFile = new File([selectedFileSuccess], 'sOMEUrl.jpg')
+    const testFile = new File([selectedFileSuccess], 'sOMEUrl.jpg');
     hooks.deleteThumbnail({ dispatch })();
-    expect(dispatch).toHaveBeenNthCalledWith(1, actions.video.updateField({ thumbnail: null}));
+    expect(dispatch).toHaveBeenNthCalledWith(1, actions.video.updateField({ thumbnail: null }));
     expect(hooks.createResampledFile).toHaveBeenCalled();
-    expect(dispatch).toHaveBeenNthCalledWith(2, thunkActions.video.uploadThumbnail({ thumbnail: testFile, emptyCanvas: true}))
+    expect(dispatch).toHaveBeenNthCalledWith(2, thunkActions.video.uploadThumbnail({
+      thumbnail: testFile,
+      emptyCanvas: true,
+    }));
   });
 });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
@@ -16,7 +16,7 @@ import {
 } from '@edx/paragon';
 import { Delete, FileUpload } from '@edx/paragon/icons';
 
-import { actions, selectors } from '../../../../../../data/redux';
+import { selectors } from '../../../../../../data/redux';
 import { acceptedImgKeys } from './constants';
 import * as hooks from './hooks';
 import messages from './messages';
@@ -36,9 +36,9 @@ export const ThumbnailWidget = ({
   isLibrary,
   allowThumbnailUpload,
   thumbnail,
-  updateField,
   videoType,
 }) => {
+  const dispatch = useDispatch();
   const [error] = React.useContext(ErrorContext).thumbnail;
   const imgRef = React.useRef();
   const [thumbnailSrc, setThumbnailSrc] = React.useState(thumbnail);
@@ -48,6 +48,7 @@ export const ThumbnailWidget = ({
     imgRef,
     fileSizeError,
   });
+  const deleteThumbnail = hooks.deleteThumbnail({ dispatch });
   const isEdxVideo = videoType === 'edxVideo';
   const getSubtitle = () => {
     if (isEdxVideo) {
@@ -58,7 +59,6 @@ export const ThumbnailWidget = ({
     }
     return intl.formatMessage(messages.unavailableSubtitle);
   };
-
   return (!isLibrary ? (
     <CollapsibleFormWidget
       isError={Object.keys(error).length !== 0}
@@ -73,7 +73,7 @@ export const ThumbnailWidget = ({
         <FormattedMessage {...messages.fileSizeError} />
       </ErrorAlert>
       {isEdxVideo ? null : (
-        <Alert variant="info">
+        <Alert variant="light">
           <FormattedMessage {...messages.unavailableMessage} />
         </Alert>
       )}
@@ -93,16 +93,16 @@ export const ThumbnailWidget = ({
               tooltipContent={intl.formatMessage(messages.deleteThumbnail)}
               iconAs={Icon}
               src={Delete}
-              onClick={() => updateField({ thumbnail: null })}
+              onClick={deleteThumbnail}
             />
           ) : null }
         </Stack>
       ) : (
         <Stack gap={3}>
-          <div>
+          <div className="text-center">
             <FormattedMessage {...messages.addThumbnail} />
           </div>
-          <div style={{ color: 'grey' }}>
+          <div className="text-center text-primary-300">
             <FormattedMessage {...messages.aspectRequirements} />
           </div>
           <FileInput fileInput={fileInput} acceptedFiles={Object.values(acceptedImgKeys).join()} />
@@ -129,7 +129,6 @@ ThumbnailWidget.propTypes = {
   isLibrary: PropTypes.bool.isRequired,
   allowThumbnailUpload: PropTypes.bool.isRequired,
   thumbnail: PropTypes.string.isRequired,
-  updateField: PropTypes.func.isRequired,
   videoType: PropTypes.string.isRequired,
 };
 export const mapStateToProps = (state) => ({
@@ -139,8 +138,6 @@ export const mapStateToProps = (state) => ({
   videoType: selectors.video.videoType(state),
 });
 
-export const mapDispatchToProps = (dispatch) => ({
-  updateField: (stateUpdate) => dispatch(actions.video.updateField(stateUpdate)),
-});
+export const mapDispatchToProps = {};
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(ThumbnailWidget));

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { formatMessage } from '../../../../../../../testUtils';
-import { actions, selectors } from '../../../../../../data/redux';
+import { selectors } from '../../../../../../data/redux';
 import { ThumbnailWidget, mapStateToProps, mapDispatchToProps } from '.';
 
 jest.mock('react', () => ({
@@ -95,9 +95,8 @@ describe('ThumbnailWidget', () => {
     });
   });
   describe('mapDispatchToProps', () => {
-    const dispatch = jest.fn();
-    test('updateField from actions.video.updateField', () => {
-      expect(mapDispatchToProps.updateField).toEqual(dispatch(actions.video.updateField));
+    test('mapDispatchToProps to equal an empty object', () => {
+      expect(mapDispatchToProps).toEqual({});
     });
   });
 });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
@@ -52,7 +52,7 @@ export const messages = {
   fileSizeError: {
     id: 'authoring.videoeditor.thumbnail.error.fileSizeError',
     defaultMessage:
-      'The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize image and try again.',
+      'The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again.',
     description:
       ' Message presented to user when file size of image is less than 2 KB or larger than 2 MB',
   },

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -180,7 +180,7 @@ export const saveVideoData = () => (dispatch, getState) => {
   return selectors.video.videoSettings(state);
 };
 
-export const uploadThumbnail = ({ thumbnail }) => (dispatch, getState) => {
+export const uploadThumbnail = ({ thumbnail, emptyCanvas }) => (dispatch, getState) => {
   const state = getState();
   const { videoId } = state.video;
   const { studioEndpointUrl } = state.app;
@@ -196,9 +196,11 @@ export const uploadThumbnail = ({ thumbnail }) => (dispatch, getState) => {
         // in stage and production, image_url is an absolute path to the image
         thumbnailUrl = response.data.image_url;
       }
-      dispatch(actions.video.updateField({
-        thumbnail: thumbnailUrl,
-      }));
+      if (!emptyCanvas) {
+        dispatch(actions.video.updateField({
+          thumbnail: thumbnailUrl,
+        }));
+      }
     },
     onFailure: (e) => console.log({ UploadFailure: e }, 'Resampling thumbnail upload'),
   }));

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -329,6 +329,15 @@ describe('video thunkActions', () => {
       );
     });
   });
+  describe('uploadThumbnail - emptyCanvas', () => {
+    beforeEach(() => {
+      thunkActions.uploadThumbnail({ thumbnail: mockThumbnail, emptyCanvas: true })(dispatch, getState);
+      [[dispatchedAction]] = dispatch.mock.calls;
+    });
+    it('dispatches uploadThumbnail action', () => {
+      expect(dispatchedAction.uploadThumbnail).not.toEqual(undefined);
+    });
+  });
   describe('deleteTranscript', () => {
     beforeEach(() => {
       thunkActions.deleteTranscript({ language: 'la' })(dispatch, getState);


### PR DESCRIPTION
JIRA Tickets: [TNL-10256](https://2u-internal.atlassian.net/browse/TNL-10256), [TNL-10247](https://2u-internal.atlassian.net/browse/TNL-10247), and [TNL-10252](https://2u-internal.atlassian.net/browse/TNL-10252)

Previously, when a thumbnail was deleted from a video it would delete in the video settings but had no impact on the xblock. This allowed the previous thumbnail to persist in the player and Video Upload page. This PR saves a black canvas as an image when the current thumbnail is deleted. The user does not see the black canvas, but it is stored to the xblock so that the previous thumbnail is not longer seen.